### PR TITLE
require Swift 4.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.1
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project


### PR DESCRIPTION
Motivation:

As swift-nio-extras is new, we can require Swift 4.1 which will allow us
to CI less stuff and also won't compatibility stuff for 4.0 that nobody
uses anymore.

Modifications:

require Swift 4.1

Result:

shinier