### PR TITLE
fix readme dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ functionality.
 ## Using NIOExtras:
 
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio-extras.git", .upToNextMinor("0.1.0")),
+        .package(url: "https://github.com/apple/swift-nio-extras.git", .upToNextMinor(from: "0.1.0")),
     ],
 
 ## Current Contents


### PR DESCRIPTION
Motivation:

in SwiftPM it's either of these three formats

- from: "0.1.0"
- .exact("0.1.0")
- .upToNextMajor(from: "0.1.0")

and I messed up the last one (forgot the `from:`)

Modifications:

fixed Package.swift

Result:

recommended syntax actually works