### PR TITLE
LineBasedFrameDecoder: add test for when data arrives after EOF

### DIFF
--- a/Sources/NIOExtras/LineBasedFrameDecoder.swift
+++ b/Sources/NIOExtras/LineBasedFrameDecoder.swift
@@ -49,8 +49,6 @@ public class LineBasedFrameDecoder: ByteToMessageDecoder {
     }
     
     public func decodeLast(context: ChannelHandlerContext, buffer: inout ByteBuffer, seenEOF: Bool) throws -> DecodingState {
-        // we'll just try to decode as much as we can as usually
-        while case .continue = try self.decode(context: context, buffer: &buffer) {}
         if buffer.readableBytes > 0 {
             context.fireErrorCaught(NIOExtrasErrors.LeftOverBytesError(leftOverBytes: buffer))
         }

--- a/Tests/NIOExtrasTests/LineBasedFrameDecoderTest+XCTest.swift
+++ b/Tests/NIOExtrasTests/LineBasedFrameDecoderTest+XCTest.swift
@@ -32,6 +32,7 @@ extension LineBasedFrameDecoderTest {
                 ("testEmptyLine", testEmptyLine),
                 ("testEmptyBuffer", testEmptyBuffer),
                 ("testChannelInactiveWithLeftOverBytes", testChannelInactiveWithLeftOverBytes),
+                ("testMoreDataAvailableWhenChannelBecomesInactive", testMoreDataAvailableWhenChannelBecomesInactive),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Before the new B2MD, the LineBasedFrameDecoder would crash if there's more data after EOF, that's long fixed but this is the test for it.

Modifications:

add test

Result:

- better test coverage
- verifies https://github.com/apple/swift-nio/pull/875