### PR TITLE
LengthFieldBasedFrameDecoder: work around brittle B2MD

### DIFF
--- a/Sources/NIOExtras/LengthFieldBasedFrameDecoder.swift
+++ b/Sources/NIOExtras/LengthFieldBasedFrameDecoder.swift
@@ -114,6 +114,11 @@ public final class LengthFieldBasedFrameDecoder: ByteToMessageDecoder {
         return .continue
     }
     
+    public func decodeLast(ctx: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
+        // work around the extreme brittleness of ByteToMessageDecoder
+        return .needMoreData
+    }
+
     ///
     /// Attempts to read the header data. Updates the status is successful.
     ///

--- a/Tests/NIOExtrasTests/FixedLengthFrameDecoderTest+XCTest.swift
+++ b/Tests/NIOExtrasTests/FixedLengthFrameDecoderTest+XCTest.swift
@@ -30,6 +30,7 @@ extension FixedLengthFrameDecoderTest {
                 ("testDecodeIfMoreBytesAreSent", testDecodeIfMoreBytesAreSent),
                 ("testRemoveHandlerWhenBufferIsNotEmpty", testRemoveHandlerWhenBufferIsNotEmpty),
                 ("testRemoveHandlerWhenBufferIsEmpty", testRemoveHandlerWhenBufferIsEmpty),
+                ("testCloseInChannelRead", testCloseInChannelRead),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

ByteToMessageDecoder is extremely brittle, for example a reentrant call
into decodeLast will present the user with bytes that were previously
seen...

Modification:

Discard bytes in decodeLast

Result:

LengthFieldBasedFrameDecoder will work if close called from channelRead.
