### PR TITLE
update to latest NIO

### DIFF
--- a/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest.swift
+++ b/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest.swift
@@ -42,10 +42,10 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         
         XCTAssertTrue(try self.channel.writeInbound(buffer))
         
-        var outputBuffer: ByteBuffer? = self.channel.readInbound()
-        let outputData = outputBuffer?.readBytes(length: dataBytes.count)
-        
-        XCTAssertEqual(dataBytes, outputData)
+        XCTAssertNoThrow(XCTAssertEqual(dataBytes,
+                                        try self.channel.readInbound(as: ByteBuffer.self)?.readableBytesView.map {
+                                            $0
+                                        }))
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -63,10 +63,10 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         
         XCTAssertTrue(try self.channel.writeInbound(buffer))
         
-        var outputBuffer: ByteBuffer? = self.channel.readInbound()
-        let outputData = outputBuffer?.readString(length: standardDataString.count)
-        
-        XCTAssertEqual(standardDataString, outputData)
+        XCTAssertNoThrow(XCTAssertEqual(standardDataString,
+                                        try (self.channel.readInbound(as: ByteBuffer.self)?.readableBytesView).map {
+                                            String(decoding: $0, as: Unicode.UTF8.self)
+                                        }))
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -84,10 +84,10 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         
         XCTAssertTrue(try self.channel.writeInbound(buffer))
         
-        var outputBuffer: ByteBuffer? = self.channel.readInbound()
-        let outputData = outputBuffer?.readString(length: standardDataString.count)
-        
-        XCTAssertEqual(standardDataString, outputData)
+        XCTAssertNoThrow(XCTAssertEqual(standardDataString,
+                                        try (self.channel.readInbound(as: ByteBuffer.self)?.readableBytesView).map {
+                                            String(decoding: $0, as: Unicode.UTF8.self)
+                                        }))
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -105,10 +105,10 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         
         XCTAssertTrue(try self.channel.writeInbound(buffer))
         
-        var outputBuffer: ByteBuffer? = self.channel.readInbound()
-        let outputData = outputBuffer?.readString(length: standardDataString.count)
-        
-        XCTAssertEqual(standardDataString, outputData)
+        XCTAssertNoThrow(XCTAssertEqual(standardDataString,
+                                        try (self.channel.readInbound(as: ByteBuffer.self)?.readableBytesView).map {
+                                            String(decoding: $0, as: Unicode.UTF8.self)
+                                        }))
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -126,10 +126,11 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         
         XCTAssertTrue(try self.channel.writeInbound(buffer))
         
-        var outputBuffer: ByteBuffer? = self.channel.readInbound()
-        let outputData = outputBuffer?.readString(length: standardDataString.count)
-        
-        XCTAssertEqual(standardDataString, outputData)
+        XCTAssertNoThrow(XCTAssertEqual(standardDataString,
+                                        try (self.channel.readInbound(as: ByteBuffer.self)?.readableBytesView).map {
+                                            String(decoding: $0, as: Unicode.UTF8.self)
+                                        }))
+
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -147,10 +148,11 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         
         XCTAssertTrue(try self.channel.writeInbound(buffer))
         
-        var outputBuffer: ByteBuffer? = self.channel.readInbound()
-        let outputData = outputBuffer?.readString(length: standardDataString.count)
-        
-        XCTAssertEqual(standardDataString, outputData)
+        XCTAssertNoThrow(XCTAssertEqual(standardDataString,
+                                        try (self.channel.readInbound(as: ByteBuffer.self)?.readableBytesView).map {
+                                            String(decoding: $0, as: Unicode.UTF8.self)
+                                        }))
+
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -167,10 +169,10 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         
         XCTAssertTrue(try self.channel.writeInbound(buffer))
         
-        var outputBuffer: ByteBuffer? = self.channel.readInbound()
-        let outputData = outputBuffer?.readString(length: standardDataString.count)
-        
-        XCTAssertEqual(standardDataString, outputData)
+        XCTAssertNoThrow(XCTAssertEqual(standardDataString,
+                                        try (self.channel.readInbound(as: ByteBuffer.self)?.readableBytesView).map {
+                                            String(decoding: $0, as: Unicode.UTF8.self)
+                                        }))
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -191,16 +193,16 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         buffer.writeString(secondFrameString)
         
         XCTAssertTrue(try self.channel.writeInbound(buffer))
-        var outputFirstFrameBuffer: ByteBuffer? = self.channel.readInbound()
-        
-        let outputFirstFrameData = outputFirstFrameBuffer?.readString(length: standardDataString.count)
-        XCTAssertEqual(standardDataString, outputFirstFrameData)
-        
-        var outputSecondFrameBuffer: ByteBuffer? = self.channel.readInbound()
-        
-        let outputSecondFrameData = outputSecondFrameBuffer?.readString(length: secondFrameString.count)
-        XCTAssertEqual(secondFrameString, outputSecondFrameData)
-        
+        XCTAssertNoThrow(XCTAssertEqual(standardDataString,
+                                        try (self.channel.readInbound(as: ByteBuffer.self)?.readableBytesView).map {
+                                            String(decoding: $0, as: Unicode.UTF8.self)
+                                        }))
+
+        XCTAssertNoThrow(XCTAssertEqual(secondFrameString,
+                                        try (self.channel.readInbound(as: ByteBuffer.self)?.readableBytesView).map {
+                                            String(decoding: $0, as: Unicode.UTF8.self)
+                                        }))
+
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -222,7 +224,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         XCTAssertFalse(try self.channel.writeInbound(firstBuffer))
         
         // Read should fail because there is not yet enough data.
-        XCTAssertNil(self.channel.readInbound())
+        XCTAssertNoThrow(XCTAssertNil(try self.channel.readInbound()))
         
         var secondBuffer = self.channel.allocator.buffer(capacity: 1) // Byte 2 of 2 byte header header
         secondBuffer.writeInteger(frameDataLengthSecondByte, endianness: .little, as: UInt8.self)
@@ -230,7 +232,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         XCTAssertFalse(try self.channel.writeInbound(secondBuffer))
         
         // Read should fail because there is not yet enough data.
-        XCTAssertNil(self.channel.readInbound())
+        XCTAssertNoThrow(XCTAssertNil(try self.channel.readInbound()))
         
         // Write and try to read each byte of the data individually
         for (index, character) in standardDataString.enumerated() {
@@ -242,17 +244,16 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 
                 XCTAssertFalse(try self.channel.writeInbound(characterBuffer))
                 // Read should fail because there is not yet enough data.
-                XCTAssertNil(self.channel.readInbound())
+                XCTAssertNoThrow(XCTAssertNil(try self.channel.readInbound()))
             } else {
                 XCTAssertTrue(try self.channel.writeInbound(characterBuffer))
             }
         }
         
-        var outputBuffer: ByteBuffer? = self.channel.readInbound()
-        
-        let outputData = outputBuffer?.readString(length: standardDataString.count)
-        XCTAssertEqual(standardDataString, outputData)
-
+        XCTAssertNoThrow(XCTAssertEqual(standardDataString,
+                                        try (self.channel.readInbound(as: ByteBuffer.self)?.readableBytesView).map {
+                                            String(decoding: $0, as: Unicode.UTF8.self)
+                                        }))
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -325,15 +326,15 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         
         XCTAssertTrue(try self.channel.writeInbound(buffer))
         
-        var outputBuffer: ByteBuffer? = self.channel.readInbound()
-        let outputData = outputBuffer?.readString(length: standardDataString.count)
-        
         let removeFuture = self.channel.pipeline.removeHandler(self.decoderUnderTest)
         (channel.eventLoop as! EmbeddedEventLoop).run()
         XCTAssertNoThrow(try removeFuture.wait())
 
         
-        XCTAssertEqual(standardDataString, outputData)
+        XCTAssertNoThrow(XCTAssertEqual(standardDataString,
+                                        try (self.channel.readInbound(as: ByteBuffer.self)?.readableBytesView).map {
+                                            String(decoding: $0, as: Unicode.UTF8.self)
+                                        }))
         XCTAssertNoThrow(try self.channel.throwIfErrorCaught())
         XCTAssertFalse(try self.channel.finish())
     }
@@ -353,9 +354,6 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         
         XCTAssertTrue(try channel.writeInbound(buffer))
         
-        var outputBuffer: ByteBuffer? = self.channel.readInbound()
-        let outputData = outputBuffer?.readString(length: standardDataString.count)
-        
         let removeFuture = self.channel.pipeline.removeHandler(self.decoderUnderTest)
         (channel.eventLoop as! EmbeddedEventLoop).run()
         XCTAssertNoThrow(try removeFuture.wait())
@@ -371,7 +369,10 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
             XCTAssertEqual(error.leftOverBytes, expectedBuffer)
         }
         
-        XCTAssertEqual(standardDataString, outputData)
+        XCTAssertNoThrow(XCTAssertEqual(standardDataString,
+                                        try (self.channel.readInbound(as: ByteBuffer.self)?.readableBytesView).map {
+                                            String(decoding: $0, as: Unicode.UTF8.self)
+                                        }))
         XCTAssertFalse(try self.channel.finish())
     }
 }

--- a/Tests/NIOExtrasTests/LengthFieldPrependerTest.swift
+++ b/Tests/NIOExtrasTests/LengthFieldPrependerTest.swift
@@ -20,7 +20,6 @@ private let standardDataString = "abcde"
 private let standardDataStringCount = standardDataString.utf8.count
 
 class LengthFieldPrependerTest: XCTestCase {
-    
     private var channel: EmbeddedChannel!
     private var encoderUnderTest: LengthFieldPrepender!
     
@@ -42,7 +41,7 @@ class LengthFieldPrependerTest: XCTestCase {
         
         XCTAssertNoThrow(try self.channel.writeAndFlush(buffer).wait())
         
-        if case .some(.byteBuffer(var headerBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var headerBuffer)) = try self.channel.readOutbound(as: IOData.self) {
             
             let outputData = headerBuffer.readBytes(length: headerBuffer.readableBytes)
             XCTAssertEqual([UInt8(dataBytes.count)],  outputData)
@@ -51,7 +50,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
             
             let outputData = outputBuffer.readBytes(length: outputBuffer.readableBytes)
             XCTAssertEqual(dataBytes,  outputData)
@@ -60,7 +59,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        XCTAssertNil(self.channel.readOutbound())
+        XCTAssertNoThrow(XCTAssertNil(try self.channel.readOutbound()))
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -78,7 +77,7 @@ class LengthFieldPrependerTest: XCTestCase {
         
         XCTAssertNoThrow(try  self.channel.writeAndFlush(buffer).wait())
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
             
             let sizeInHeader = outputBuffer.readInteger(endianness: endianness, as: UInt16.self).map({ Int($0) })
             XCTAssertEqual(standardDataStringCount, sizeInHeader)
@@ -90,7 +89,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
             
             let bodyString = outputBuffer.readString(length: standardDataStringCount)
             XCTAssertEqual(standardDataString, bodyString)
@@ -102,7 +101,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        XCTAssertNil(self.channel.readOutbound())
+        XCTAssertNoThrow(XCTAssertNil(try self.channel.readOutbound()))
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -120,7 +119,7 @@ class LengthFieldPrependerTest: XCTestCase {
         
         XCTAssertNoThrow(try  self.channel.writeAndFlush(buffer).wait())
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
             
             let sizeInHeader = outputBuffer.readInteger(endianness: endianness, as: UInt32.self).map({ Int($0) })
             XCTAssertEqual(standardDataStringCount, sizeInHeader)
@@ -132,7 +131,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
             
             let bodyString = outputBuffer.readString(length: standardDataStringCount)
             XCTAssertEqual(standardDataString, bodyString)
@@ -144,7 +143,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        XCTAssertNil(self.channel.readOutbound())
+        XCTAssertNoThrow(XCTAssertNil(try self.channel.readOutbound()))
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -162,7 +161,7 @@ class LengthFieldPrependerTest: XCTestCase {
         
         XCTAssertNoThrow(try self.channel.writeAndFlush(buffer).wait())
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
             
             let sizeInHeader = outputBuffer.readInteger(endianness: endianness, as: UInt64.self).map({ Int($0) })
             XCTAssertEqual(standardDataStringCount, sizeInHeader)
@@ -174,7 +173,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
             
             let bodyString = outputBuffer.readString(length: outputBuffer.readableBytes)
             XCTAssertEqual(standardDataString, bodyString)
@@ -183,7 +182,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        XCTAssertNil(self.channel.readOutbound())
+        XCTAssertNoThrow(XCTAssertNil(try self.channel.readOutbound()))
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -201,7 +200,7 @@ class LengthFieldPrependerTest: XCTestCase {
         
         XCTAssertNoThrow(try self.channel.writeAndFlush(buffer).wait())
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
             
             let sizeInHeader = outputBuffer.readInteger(endianness: endianness, as: Int64.self).map({ Int($0) })
             XCTAssertEqual(standardDataStringCount, sizeInHeader)
@@ -213,7 +212,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
 
             let bodyString = outputBuffer.readString(length: standardDataStringCount)
             XCTAssertEqual(standardDataString, bodyString)
@@ -225,7 +224,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        XCTAssertNil(self.channel.readOutbound())
+        XCTAssertNoThrow(XCTAssertNil(try self.channel.readOutbound()))
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -243,7 +242,7 @@ class LengthFieldPrependerTest: XCTestCase {
         
         XCTAssertNoThrow(try self.channel.writeAndFlush(buffer).wait())
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
             
             let sizeInHeader = outputBuffer.readInteger(endianness: endianness, as: UInt64.self).map({ Int($0) })
             XCTAssertEqual(standardDataStringCount, sizeInHeader)
@@ -255,7 +254,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
 
             let bodyString = outputBuffer.readString(length: standardDataStringCount)
             XCTAssertEqual(standardDataString, bodyString)
@@ -267,7 +266,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        XCTAssertNil(self.channel.readOutbound())
+        XCTAssertNoThrow(XCTAssertNil(try self.channel.readOutbound()))
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -282,7 +281,7 @@ class LengthFieldPrependerTest: XCTestCase {
         
         XCTAssertNoThrow(try self.channel.writeAndFlush(buffer).wait())
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
             
             let sizeInHeader = outputBuffer.readInteger(endianness: .big, as: UInt64.self).map({ Int($0) })
             XCTAssertEqual(standardDataStringCount, sizeInHeader)
@@ -294,7 +293,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
             
             let bodyString = outputBuffer.readString(length: standardDataStringCount)
             XCTAssertEqual(standardDataString, bodyString)
@@ -306,7 +305,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        XCTAssertNil(self.channel.readOutbound())
+        XCTAssertNoThrow(XCTAssertNil(try self.channel.readOutbound()))
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -323,7 +322,7 @@ class LengthFieldPrependerTest: XCTestCase {
         
         XCTAssertNoThrow(try self.channel.writeAndFlush(buffer).wait())
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
             
             let sizeInHeader = outputBuffer.readInteger(endianness: endianness, as: UInt64.self).map({ Int($0) })
             XCTAssertEqual(0, sizeInHeader)
@@ -336,11 +335,11 @@ class LengthFieldPrependerTest: XCTestCase {
         }
         
         // Check that if there is any more buffer it has a zero size.
-        if case .some(.byteBuffer(let outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(let outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
             XCTAssertEqual(0, outputBuffer.readableBytes)
         }
         
-        XCTAssertNil(self.channel.readOutbound())
+        XCTAssertNoThrow(XCTAssertNil(try self.channel.readOutbound()))
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -360,7 +359,7 @@ class LengthFieldPrependerTest: XCTestCase {
         
         XCTAssertNoThrow(try self.channel.writeAndFlush(buffer).wait())
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
             
             let sizeInHeader = outputBuffer.readInteger(endianness: endianness, as: UInt64.self).map({ Int($0) })
             XCTAssertEqual(contents.count, sizeInHeader)
@@ -372,7 +371,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        if case .some(.byteBuffer(var outputBuffer)) = self.channel.readOutbound(as: IOData.self) {
+        if case .some(.byteBuffer(var outputBuffer)) = try self.channel.readOutbound(as: IOData.self) {
 
             let bodyData = outputBuffer.readBytes(length: outputBuffer.readableBytes)
             XCTAssertEqual(contents, bodyData)
@@ -381,7 +380,7 @@ class LengthFieldPrependerTest: XCTestCase {
             XCTFail("couldn't read ByteBuffer from channel")
         }
         
-        XCTAssertNil(self.channel.readOutbound())
+        XCTAssertNoThrow(XCTAssertNil(try self.channel.readOutbound()))
         XCTAssertFalse(try self.channel.finish())
     }
     
@@ -407,7 +406,7 @@ class LengthFieldPrependerTest: XCTestCase {
                            error as? LengthFieldPrependerError)
         }
         
-        XCTAssertNil(self.channel.readOutbound())
+        XCTAssertNoThrow(XCTAssertNil(try self.channel.readOutbound()))
         XCTAssertFalse(try self.channel.finish())
     }
 }

--- a/Tests/NIOExtrasTests/RequestResponseHandlerTest.swift
+++ b/Tests/NIOExtrasTests/RequestResponseHandlerTest.swift
@@ -52,14 +52,14 @@ class RequestResponseHandlerTest: XCTestCase {
         // write response
         XCTAssertNoThrow(try self.channel.writeInbound("okay"))
         // verify request was forwarded
-        XCTAssertEqual(IOData.byteBuffer(self.buffer), self.channel.readOutbound())
+        XCTAssertNoThrow(XCTAssertEqual(IOData.byteBuffer(self.buffer), try self.channel.readOutbound()))
         // verify response was not forwarded
-        XCTAssertEqual(nil, self.channel.readInbound() as IOData?)
+        XCTAssertNoThrow(XCTAssertEqual(nil, try self.channel.readInbound(as: IOData.self)))
         // verify the promise got succeeded with the response
         XCTAssertNoThrow(XCTAssertEqual("okay", try p.futureResult.wait()))
     }
 
-    func testEnqueingMultipleRequestsWorks() {
+    func testEnqueingMultipleRequestsWorks() throws {
         struct DummyError: Error {}
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(RequestResponseHandler<IOData, Int>()).wait())
 
@@ -80,7 +80,7 @@ class RequestResponseHandlerTest: XCTestCase {
 
         // let's have 3 successful responses
         for reqIdExpected in 0..<3 {
-            switch self.channel.readOutbound(as: IOData.self) {
+            switch try self.channel.readOutbound(as: IOData.self) {
             case .some(.byteBuffer(var buffer)):
                 if let reqId = buffer.readString(length: buffer.readableBytes).flatMap(Int.init) {
                     // write response
@@ -108,7 +108,7 @@ class RequestResponseHandlerTest: XCTestCase {
         }
 
         // verify no response was not forwarded
-        XCTAssertEqual(nil, self.channel.readInbound() as IOData?)
+        XCTAssertNoThrow(XCTAssertEqual(nil, try self.channel.readInbound(as: IOData.self)))
     }
 
     func testRequestsEnqueuedAfterErrorAreFailed() {


### PR DESCRIPTION
Motivation:

Code broke again (mostly EmbeddedChannel.readInbound/Outbound which is
now throwing)

Modifications:

make code compile again

Result:

happy
