### PR TITLE
make HTTPResponseCompressor removable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,17 +16,16 @@
 import PackageDescription
 
 var targets: [PackageDescription.Target] = [
-    .target(name: "NIOExtras", dependencies: ["NIO", "_NIO1APIShims"]),
+    .target(name: "NIOExtras", dependencies: ["NIO"]),
     .target(name: "NIOHTTPCompression", dependencies: ["NIO", "NIOHTTP1", "CNIOExtrasZlib"]),
-    .target(name: "HTTPServerWithQuiescingDemo", dependencies: ["NIOExtras", "NIOHTTP1", "_NIO1APIShims"]),
+    .target(name: "HTTPServerWithQuiescingDemo", dependencies: ["NIOExtras", "NIOHTTP1"]),
     .target(name: "CNIOExtrasZlib",
             dependencies: [],
             linkerSettings: [
                 .linkedLibrary("z")
             ]),
-    .testTarget(name: "NIOExtrasTests", dependencies: ["NIOExtras", "_NIO1APIShims"]),
-    .testTarget(name: "NIOHTTPCompressionTests", dependencies:
-    ["NIOHTTPCompression", "_NIO1APIShims"]),
+    .testTarget(name: "NIOExtrasTests", dependencies: ["NIOExtras"]),
+    .testTarget(name: "NIOHTTPCompressionTests", dependencies: ["NIOHTTPCompression"]),
 ]
 
 let package = Package(

--- a/Sources/HTTPServerWithQuiescingDemo/main.swift
+++ b/Sources/HTTPServerWithQuiescingDemo/main.swift
@@ -12,11 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Dispatch
+
 import NIO
-import _NIO1APIShims
 import NIOHTTP1
 import NIOExtras
-import Dispatch
 
 private final class HTTPHandler: ChannelInboundHandler {
     typealias InboundIn = HTTPServerRequestPart

--- a/Sources/NIOExtras/DebugInboundEventsHandler.swift
+++ b/Sources/NIOExtras/DebugInboundEventsHandler.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
-import _NIO1APIShims
 
 /// ChannelInboundHandler that prints all inbound events that pass through the pipeline by default,
 /// overridable by providing your own closure for custom logging. See DebugOutboundEventsHandler for outbound events.

--- a/Sources/NIOHTTPCompression/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTPCompression/HTTPResponseCompressor.swift
@@ -57,7 +57,7 @@ private func qValueFromHeader(_ text: String) -> Float {
 /// ahead-of-time instead of dynamically, could be a waste of CPU time and latency for relatively minimal
 /// benefit. This channel handler should be present in the pipeline only for dynamically-generated and
 /// highly-compressible content, which will see the biggest benefits from streaming compression.
-public final class HTTPResponseCompressor: ChannelDuplexHandler {
+public final class HTTPResponseCompressor: ChannelDuplexHandler, RemovableChannelHandler {
     public typealias InboundIn = HTTPServerRequestPart
     public typealias InboundOut = HTTPServerRequestPart
     public typealias OutboundIn = HTTPServerResponsePart

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest+XCTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest+XCTest.swift
@@ -50,6 +50,7 @@ extension HTTPResponseCompressorTest {
                 ("testStartsWithSameUnicodeScalarsWorksOnPrefix", testStartsWithSameUnicodeScalarsWorksOnPrefix),
                 ("testStartsWithSameUnicodeScalarsSaysNoForTheSameStringInDifferentNormalisations", testStartsWithSameUnicodeScalarsSaysNoForTheSameStringInDifferentNormalisations),
                 ("testStartsWithSaysYesForTheSameStringInDifferentNormalisations", testStartsWithSaysYesForTheSameStringInDifferentNormalisations),
+                ("testCanBeRemoved", testCanBeRemoved),
            ]
    }
 }

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
@@ -581,4 +581,21 @@ class HTTPResponseCompressorTest: XCTestCase {
         XCTAssertTrue(nfcEncodedEAigu.starts(with: nfdEncodedEAigu))
         XCTAssertTrue(nfdEncodedEAigu.starts(with: nfcEncodedEAigu))
     }
+
+    func testCanBeRemoved() throws {
+        let channel = try compressionChannel()
+        defer {
+            XCTAssertNoThrow(try channel.finish())
+        }
+
+        try sendRequest(acceptEncoding: "deflate", channel: channel)
+        try assertDeflatedResponse(channel: channel)
+
+        XCTAssertNoThrow(try channel.pipeline.context(handlerType: HTTPResponseCompressor.self).flatMap { context in
+            channel.pipeline.removeHandler(context: context)
+        }.wait())
+
+        try sendRequest(acceptEncoding: "deflate", channel: channel)
+        try assertUncompressedResponse(channel: channel)
+    }
 }


### PR DESCRIPTION
Motivation:

HTTPResponseCompressor is trivially removable, so mark it.

Modifications:

make HTTPResponseCompressor implement RemovableChannelHandler

Result:

HTTPResponseCompressor can be removed