### PR TITLE
depend on swift-nio: 2.0.0-convergence.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         .library(name: "NIOHTTPCompression", targets: ["NIOHTTPCompression"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", .branch("master")),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0-convergence.1"),
     ],
     targets: targets
 )


### PR DESCRIPTION
Motivation:

to tag versions, we shouldn't depend on `.branch("master")`

Modifications:

depend on swift-nio: 2.0.0-convergence.1

Result:

ready to soon tag the first version