### PR TITLE
LineBasedFrameDecoder: Don't discard everything after EOF

### DIFF
--- a/Sources/NIOExtras/LineBasedFrameDecoder.swift
+++ b/Sources/NIOExtras/LineBasedFrameDecoder.swift
@@ -49,6 +49,7 @@ public class LineBasedFrameDecoder: ByteToMessageDecoder {
     }
     
     public func decodeLast(context: ChannelHandlerContext, buffer: inout ByteBuffer, seenEOF: Bool) throws -> DecodingState {
+        while try self.decode(context: context, buffer: &buffer) == .continue {}
         if buffer.readableBytes > 0 {
             context.fireErrorCaught(NIOExtrasErrors.LeftOverBytesError(leftOverBytes: buffer))
         }


### PR DESCRIPTION
Motivation:

LineBasedFrameDecoder discarded everything after EOF and delivered it in
the left-over bytes error. For the real world however that doesn't make
much sense, you'd want all previously received lines and only receive
the partial lines as left-overs.

Modifications:

deliver lines until there are only partial lines left, even in case of
EOF.

Result:

LineBasedFrameDecoder more useful