### PR TITLE
LineBasedFrameDecoder: tolerate drip fed \r\n

### DIFF
--- a/Sources/NIOExtras/LineBasedFrameDecoder.swift
+++ b/Sources/NIOExtras/LineBasedFrameDecoder.swift
@@ -61,7 +61,8 @@ public class LineBasedFrameDecoder: ByteToMessageDecoder {
         // look for the delimiter
         if let delimiterIndex = view.firstIndex(of: 0x0A) { // '\n'
             let length = delimiterIndex - buffer.readerIndex
-            let dropCarriageReturn = delimiterIndex > view.startIndex && view[delimiterIndex - 1] == 0x0D // '\r'
+            let dropCarriageReturn = delimiterIndex > buffer.readableBytesView.startIndex &&
+                buffer.readableBytesView[delimiterIndex - 1] == 0x0D // '\r'
             let buff = buffer.readSlice(length: dropCarriageReturn ? length - 1 : length)
             // drop the delimiter (and trailing carriage return if appicable)
             buffer.moveReaderIndex(forwardBy: dropCarriageReturn ? 2 : 1)

--- a/Tests/NIOExtrasTests/LineBasedFrameDecoderTest+XCTest.swift
+++ b/Tests/NIOExtrasTests/LineBasedFrameDecoderTest+XCTest.swift
@@ -33,6 +33,7 @@ extension LineBasedFrameDecoderTest {
                 ("testEmptyBuffer", testEmptyBuffer),
                 ("testChannelInactiveWithLeftOverBytes", testChannelInactiveWithLeftOverBytes),
                 ("testMoreDataAvailableWhenChannelBecomesInactive", testMoreDataAvailableWhenChannelBecomesInactive),
+                ("testDripFedCRLN", testDripFedCRLN),
            ]
    }
 }

--- a/Tests/NIOExtrasTests/LineBasedFrameDecoderTest.swift
+++ b/Tests/NIOExtrasTests/LineBasedFrameDecoderTest.swift
@@ -173,4 +173,17 @@ class LineBasedFrameDecoderTest: XCTestCase {
                                             String(decoding: receivedLeftOversPromise.futureResult.wait().readableBytesView,
                                                    as: UTF8.self)))
     }
+
+    func testDripFedCRLN() {
+        var buffer = self.channel.allocator.buffer(capacity: 1)
+
+        for byte in ["a", "\r", "\n"].flatMap({ $0.utf8 }) {
+            buffer.clear()
+            buffer.writeInteger(byte)
+            XCTAssertNoThrow(try self.channel.writeInbound(buffer))
+        }
+        buffer.clear()
+        buffer.writeString("a")
+        XCTAssertNoThrow(XCTAssertEqual(buffer, try self.channel.readInbound()))
+    }
 }


### PR DESCRIPTION
Motivation:

LineBasedFrameDecoder previously would only correctly decode \r\n as a
line-ending iff \r\n were not split apart.

Modifications:

Handle \r\n arriving apart.

Result:

more correct line splitting