### PR TITLE
ServerQuiescingHelper: don't swallow close errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ var targets: [PackageDescription.Target] = [
             linkerSettings: [
                 .linkedLibrary("z")
             ]),
-    .testTarget(name: "NIOExtrasTests", dependencies: ["NIOExtras", "NIOTestUtils"]),
+    .testTarget(name: "NIOExtrasTests", dependencies: ["NIOExtras", "NIO", "NIOTestUtils"]),
     .testTarget(name: "NIOHTTPCompressionTests", dependencies: ["NIOHTTPCompression"]),
 ]
 

--- a/Tests/NIOExtrasTests/QuiescingHelperTest+XCTest.swift
+++ b/Tests/NIOExtrasTests/QuiescingHelperTest+XCTest.swift
@@ -28,6 +28,7 @@ extension QuiescingHelperTest {
       return [
                 ("testShutdownIsImmediateWhenNoChannelsCollected", testShutdownIsImmediateWhenNoChannelsCollected),
                 ("testQuiesceUserEventReceivedOnShutdown", testQuiesceUserEventReceivedOnShutdown),
+                ("testQuiescingDoesNotSwallowCloseErrorsFromAcceptHandler", testQuiescingDoesNotSwallowCloseErrorsFromAcceptHandler),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

ServerQuiescingHelper used to swallow close errors and it shoulnd't do
that.

Modifications:

Don't swallow close errors.

Result:

More correctness.