### PR TITLE
extract common classes for server request decompressor

### DIFF
--- a/Sources/NIOHTTPCompression/HTTPDecompression.swift
+++ b/Sources/NIOHTTPCompression/HTTPDecompression.swift
@@ -18,13 +18,13 @@ import NIO
 public enum NIOHTTPDecompression {
     /// Specifies how to limit decompression inflation.
     public struct DecompressionLimit {
-        enum Limit {
+        private enum Limit {
             case none
             case size(Int)
             case ratio(Int)
         }
 
-        var limit: Limit
+        private var limit: Limit
 
         /// No limit will be set.
         public static let none = DecompressionLimit(limit: .none)
@@ -77,19 +77,12 @@ public enum NIOHTTPDecompression {
     }
 }
 
-
 struct Decompressor {
-    enum State {
-        case empty
-        case compressed(NIOHTTPDecompression.CompressionAlgorithm, Int)
-    }
+    private let limit: NIOHTTPDecompression.DecompressionLimit
+    private var stream = z_stream()
+    private var inflated = 0
 
-    let limit: NIOHTTPDecompression.DecompressionLimit
-    var state = State.empty
-    var stream = z_stream()
-    var inflated = 0
-
-    public init(limit: NIOHTTPDecompression.DecompressionLimit) {
+    init(limit: NIOHTTPDecompression.DecompressionLimit) {
         self.limit = limit
     }
 
@@ -103,8 +96,6 @@ struct Decompressor {
     }
 
     mutating func initializeDecoder(encoding: NIOHTTPDecompression.CompressionAlgorithm, length: Int) throws {
-        self.state = .compressed(encoding, length)
-
         self.stream.zalloc = nil
         self.stream.zfree = nil
         self.stream.opaque = nil

--- a/Sources/NIOHTTPCompression/HTTPDecompression.swift
+++ b/Sources/NIOHTTPCompression/HTTPDecompression.swift
@@ -1,0 +1,156 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CNIOExtrasZlib
+import NIO
+
+public enum NIOHTTPDecompression {
+    /// Specifies how to limit decompression inflation.
+    public struct DecompressionLimit {
+        enum Limit {
+            case none
+            case size(Int)
+            case ratio(Int)
+        }
+
+        var limit: Limit
+
+        /// No limit will be set.
+        public static let none = DecompressionLimit(limit: .none)
+        /// Limit will be set on the request body size.
+        public static func size(_ value: Int) -> DecompressionLimit { return DecompressionLimit(limit: .size(value)) }
+        /// Limit will be set on a ratio between compressed body size and decompressed result.
+        public static func ratio(_ value: Int) -> DecompressionLimit { return DecompressionLimit(limit: .ratio(value)) }
+
+        func exceeded(compressed: Int, decompressed: Int) -> Bool {
+            switch self.limit {
+            case .none:
+                return false
+            case .size(let allowed):
+                return compressed > allowed
+            case .ratio(let ratio):
+                return decompressed > compressed * ratio
+            }
+        }
+    }
+
+    public enum DecompressionError: Error {
+        case limit
+        case inflationError(Int)
+        case initializationError(Int)
+    }
+
+    enum CompressionAlgorithm: String {
+        case gzip
+        case deflate
+
+        init?(header: String?) {
+            switch header {
+            case .some("gzip"):
+                self = .gzip
+            case .some("deflate"):
+                self = .deflate
+            default:
+                return nil
+            }
+        }
+
+        var window: CInt {
+            switch self {
+            case .deflate:
+                return 15
+            case .gzip:
+                return 15 + 16
+            }
+        }
+    }
+}
+
+
+struct Decompressor {
+    enum State {
+        case empty
+        case compressed(NIOHTTPDecompression.CompressionAlgorithm, Int)
+    }
+
+    let limit: NIOHTTPDecompression.DecompressionLimit
+    var state = State.empty
+    var stream = z_stream()
+    var inflated = 0
+
+    public init(limit: NIOHTTPDecompression.DecompressionLimit) {
+        self.limit = limit
+    }
+
+    mutating func decompress(part: inout ByteBuffer, buffer: inout ByteBuffer, originalLength: Int) throws {
+        try self.stream.inflatePart(input: &part, output: &buffer)
+        self.inflated += buffer.readableBytes
+
+        if self.limit.exceeded(compressed: originalLength, decompressed: self.inflated) {
+            throw NIOHTTPDecompression.DecompressionError.limit
+        }
+    }
+
+    mutating func initializeDecoder(encoding: NIOHTTPDecompression.CompressionAlgorithm, length: Int) throws {
+        self.state = .compressed(encoding, length)
+
+        self.stream.zalloc = nil
+        self.stream.zfree = nil
+        self.stream.opaque = nil
+
+        let rc = CNIOExtrasZlib_inflateInit2(&self.stream, encoding.window)
+        guard rc == Z_OK else {
+            throw NIOHTTPDecompression.DecompressionError.initializationError(Int(rc))
+        }
+    }
+
+    mutating func deinitializeDecoder() {
+        inflateEnd(&self.stream)
+    }
+}
+
+
+extension z_stream {
+    mutating func inflatePart(input: inout ByteBuffer, output: inout ByteBuffer) throws {
+        try input.readWithUnsafeMutableReadableBytes { pointer in
+            self.avail_in = UInt32(pointer.count)
+            self.next_in = CNIOExtrasZlib_voidPtr_to_BytefPtr(pointer.baseAddress!)
+
+            defer {
+                self.avail_in = 0
+                self.next_in = nil
+                self.avail_out = 0
+                self.next_out = nil
+            }
+
+            try self.inflatePart(to: &output)
+
+            return pointer.count - Int(self.avail_in)
+        }
+    }
+
+    private mutating func inflatePart(to buffer: inout ByteBuffer) throws {
+        try buffer.writeWithUnsafeMutableBytes { pointer in
+            self.avail_out = UInt32(pointer.count)
+            self.next_out = CNIOExtrasZlib_voidPtr_to_BytefPtr(pointer.baseAddress!)
+
+            let rc = inflate(&self, Z_NO_FLUSH)
+            guard rc == Z_OK || rc == Z_STREAM_END else {
+                throw NIOHTTPDecompression.DecompressionError.inflationError(Int(rc))
+            }
+
+            return pointer.count - Int(self.avail_out)
+        }
+    }
+}

--- a/Sources/NIOHTTPCompression/HTTPDecompression.swift
+++ b/Sources/NIOHTTPCompression/HTTPDecompression.swift
@@ -86,6 +86,8 @@ public enum NIOHTTPDecompression {
         }
 
         mutating func decompress(part: inout ByteBuffer, buffer: inout ByteBuffer, originalLength: Int) throws {
+            buffer.reserveCapacity(part.readableBytes * 2)
+
             self.inflated += try self.stream.inflatePart(input: &part, output: &buffer)
 
             if self.limit.exceeded(compressed: originalLength, decompressed: self.inflated) {

--- a/Sources/NIOHTTPCompression/HTTPResponseDecompressor.swift
+++ b/Sources/NIOHTTPCompression/HTTPResponseDecompressor.swift
@@ -27,10 +27,10 @@ public final class NIOHTTPResponseDecompressor: ChannelDuplexHandler, RemovableC
     }
 
     private var state = State.empty
-    private var decompressor: Decompressor
+    private var decompressor: NIOHTTPDecompression.Decompressor
 
     public init(limit: NIOHTTPDecompression.DecompressionLimit) {
-        self.decompressor = Decompressor(limit: limit)
+        self.decompressor = NIOHTTPDecompression.Decompressor(limit: limit)
     }
 
     public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {

--- a/Sources/NIOHTTPCompression/HTTPResponseDecompressor.swift
+++ b/Sources/NIOHTTPCompression/HTTPResponseDecompressor.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import CNIOExtrasZlib
 import NIO
 import NIOHTTP1
 
@@ -22,78 +21,10 @@ public final class NIOHTTPResponseDecompressor: ChannelDuplexHandler, RemovableC
     public typealias OutboundIn = HTTPClientRequestPart
     public typealias OutboundOut = HTTPClientRequestPart
 
-    /// Specifies how to limit decompression inflation.
-    public struct DecompressionLimit {
-        enum Limit {
-            case none
-            case size(Int)
-            case ratio(Int)
-        }
+    private var decompressor: Decompressor
 
-        var limit: Limit
-
-        /// No limit will be set.
-        public static let none = DecompressionLimit(limit: .none)
-        /// Limit will be set on the request body size.
-        public static func size(_ value: Int) -> DecompressionLimit { return DecompressionLimit(limit: .size(value)) }
-        /// Limit will be set on a ratio between compressed body size and decompressed result.
-        public static func ratio(_ value: Int) -> DecompressionLimit { return DecompressionLimit(limit: .ratio(value)) }
-
-        func exceeded(compressed: Int, decompressed: Int) -> Bool {
-            switch self.limit {
-            case .none:
-                return false
-            case .size(let allowed):
-                return compressed > allowed
-            case .ratio(let ratio):
-                return decompressed > compressed * ratio
-            }
-        }
-    }
-
-    public enum DecompressionError: Error {
-        case limit
-        case inflationError(Int)
-        case initializationError(Int)
-    }
-
-    private enum CompressionAlgorithm: String {
-        case gzip
-        case deflate
-
-        init?(header: String?) {
-            switch header {
-            case .some("gzip"):
-                self = .gzip
-            case .some("deflate"):
-                self = .deflate
-            default:
-                return nil
-            }
-        }
-
-        var window: Int32 {
-            switch self {
-            case .deflate:
-                return 15
-            case .gzip:
-                return 15 + 16
-            }
-        }
-    }
-
-    private enum State {
-        case empty
-        case compressed(CompressionAlgorithm, Int)
-    }
-
-    private let limit: DecompressionLimit
-    private var state = State.empty
-    private var stream = z_stream()
-    private var inflated = 0
-
-    public init(limit: DecompressionLimit) {
-        self.limit = limit
+    public init(limit: NIOHTTPDecompression.DecompressionLimit) {
+        self.decompressor = Decompressor(limit: limit)
     }
 
     public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
@@ -115,13 +46,13 @@ public final class NIOHTTPResponseDecompressor: ChannelDuplexHandler, RemovableC
         switch self.unwrapInboundIn(data) {
         case .head(let head):
             let contentType = head.headers[canonicalForm: "Content-Encoding"].first?.lowercased()
-            let algorithm = CompressionAlgorithm(header: contentType)
+            let algorithm = NIOHTTPDecompression.CompressionAlgorithm(header: contentType)
 
             let length = head.headers[canonicalForm: "Content-Length"].first.flatMap { Int($0) }
 
             if let algorithm = algorithm, let length = length {
                 do {
-                    try self.initializeDecoder(encoding: algorithm, length: length)
+                    try self.decompressor.initializeDecoder(encoding: algorithm, length: length)
                 } catch {
                     context.fireErrorCaught(error)
                     return
@@ -130,83 +61,30 @@ public final class NIOHTTPResponseDecompressor: ChannelDuplexHandler, RemovableC
 
             context.fireChannelRead(data)
         case .body(var part):
-            switch self.state {
+            switch self.decompressor.state {
             case .compressed(_, let originalLength):
                 while part.readableBytes > 0 {
+                    var buffer = context.channel.allocator.buffer(capacity: 16384)
                     do {
-                        var buffer = context.channel.allocator.buffer(capacity: 16384)
-                        try self.stream.inflatePart(input: &part, output: &buffer)
-                        self.inflated += buffer.readableBytes
-
-                        if self.limit.exceeded(compressed: originalLength, decompressed: self.inflated) {
-                            context.fireErrorCaught(DecompressionError.limit)
-                            return
-                        }
-
-                        context.fireChannelRead(self.wrapInboundOut(.body(buffer)))
+                        try self.decompressor.decompress(part: &part, buffer: &buffer, originalLength: originalLength)
                     } catch {
                         context.fireErrorCaught(error)
                         return
                     }
+
+                    context.fireChannelRead(self.wrapInboundOut(.body(buffer)))
                 }
             default:
                 context.fireChannelRead(data)
             }
         case .end:
-            switch self.state {
+            switch self.decompressor.state {
             case .compressed:
-                inflateEnd(&self.stream)
+                self.decompressor.deinitializeDecoder()
             default:
                 break
             }
             context.fireChannelRead(data)
-        }
-    }
-
-    private func initializeDecoder(encoding: CompressionAlgorithm, length: Int) throws {
-        self.state = .compressed(encoding, length)
-
-        self.stream.zalloc = nil
-        self.stream.zfree = nil
-        self.stream.opaque = nil
-
-        let rc = CNIOExtrasZlib_inflateInit2(&self.stream, encoding.window)
-        guard rc == Z_OK else {
-            throw DecompressionError.initializationError(Int(rc))
-        }
-    }
-}
-
-extension z_stream {
-    mutating func inflatePart(input: inout ByteBuffer, output: inout ByteBuffer) throws {
-        try input.readWithUnsafeMutableReadableBytes { pointer in
-            self.avail_in = UInt32(pointer.count)
-            self.next_in = CNIOExtrasZlib_voidPtr_to_BytefPtr(pointer.baseAddress!)
-
-            defer {
-                self.avail_in = 0
-                self.next_in = nil
-                self.avail_out = 0
-                self.next_out = nil
-            }
-
-            try self.inflatePart(to: &output)
-
-            return pointer.count - Int(self.avail_in)
-        }
-    }
-
-    private mutating func inflatePart(to buffer: inout ByteBuffer) throws {
-        try buffer.writeWithUnsafeMutableBytes { pointer in
-            self.avail_out = UInt32(pointer.count)
-            self.next_out = CNIOExtrasZlib_voidPtr_to_BytefPtr(pointer.baseAddress!)
-
-            let rc = inflate(&self, Z_NO_FLUSH)
-            guard rc == Z_OK || rc == Z_STREAM_END else {
-                throw NIOHTTPResponseDecompressor.DecompressionError.inflationError(Int(rc))
-            }
-
-            return pointer.count - Int(self.avail_out)
         }
     }
 }

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest.swift
@@ -40,7 +40,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
         let body = ByteBuffer.of(bytes: [120, 156, 75, 76, 28, 5, 200, 0, 0, 248, 66, 103, 17])
         do {
             try channel.writeInbound(HTTPClientResponsePart.body(body))
-        } catch let error as NIOHTTPResponseDecompressor.DecompressionError {
+        } catch let error as NIOHTTPDecompression.DecompressionError {
             switch error {
             case .limit:
                 // ok
@@ -63,7 +63,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
         let body = ByteBuffer.of(bytes: [120, 156, 75, 76, 28, 5, 200, 0, 0, 248, 66, 103, 17])
         do {
             try channel.writeInbound(HTTPClientResponsePart.body(body))
-        } catch let error as NIOHTTPResponseDecompressor.DecompressionError {
+        } catch let error as NIOHTTPDecompression.DecompressionError {
             switch error {
             case .limit:
                 // ok
@@ -100,7 +100,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
 
             do {
                 try channel.writeInbound(HTTPClientResponsePart.body(compressed))
-            } catch let error as NIOHTTPResponseDecompressor.DecompressionError {
+            } catch let error as NIOHTTPDecompression.DecompressionError {
                 switch error {
                 case .limit:
                     // ok


### PR DESCRIPTION
Extract common decompression functions and types for future HTTP Request Decompressor

### Motivation:
Changes introduced in #56 could be used as a baseline for #59, but in order for second PR to be merged we need to extract common functionality and common types first.

### Modifications:
Introduced a namespace for all common public types: `NIOHTTPDecompression`
Introduced a common decompression utility type: `Decompressor` that can be reused between response and request decompressors

### Result:
Request decompression PR should be much simpler now.