### PR TITLE
test runner: add -x to bash invocations

### DIFF
--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -10,5 +10,5 @@ services:
         swift_version: "5.1"
 
   test:
-    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors --sanitize=thread"
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --sanitize=thread"
     image: swift-nio-extras:16.04-5.1

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -10,5 +10,5 @@ services:
         swift_version: "5.0"
 
   test:
-    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors"
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors"
     image: swift-nio-extras:18.04-5.0


### PR DESCRIPTION
Motivation:

It's important to see the commands that are run in CI.

Modification:

Add -x to the bash invocations.

Result:

More clarity on what is run.