### PR TITLE
Add --sanitize=thread to test invocation

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -25,4 +25,4 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"
+    command: /bin/bash -xcl "swift test --sanitize=thread -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"


### PR DESCRIPTION
Use thread sanitizer for testing

### Motivation:

This allows us to test correct threading behavior when testing

### Modifications:

Add `--sanitize=thread` the the test invocation command

### Result:

Resolves #58 
