### PR TITLE
Clean up test command in docker config files

### DIFF
--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -10,5 +10,6 @@ services:
         swift_version: "5.1"
 
   test:
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --sanitize=thread"
     image: swift-nio-extras:16.04-5.1
+    environment:
+      - SANITIZER_ARG=--sanitize=thread

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -10,5 +10,4 @@ services:
         swift_version: "5.0"
 
   test:
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors"
     image: swift-nio-extras:18.04-5.0

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -25,4 +25,4 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift test --sanitize=thread -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"


### PR DESCRIPTION
Only set the test command on the base config file and pass in the sanitizer argument for the 5.1 image (as 5.0 doesn't support the thread sanitizer)

### Motivation:

We want to run the thread sanitizer to find threading issues

### Modifications:

Remove the test command from the distro specific config files and only have it on the base config. Set the `SANITIZER_ARG` variable on the 5.1 specific config file.

### Result:

Thread sanitizer is run for the Swift 5.1 docker image tests
