### PR TITLE
don't use @tesable import NIO in test suite

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ var targets: [PackageDescription.Target] = [
             linkerSettings: [
                 .linkedLibrary("z")
             ]),
-    .testTarget(name: "NIOExtrasTests", dependencies: ["NIOExtras", "NIO", "NIOTestUtils"]),
+    .testTarget(name: "NIOExtrasTests", dependencies: ["NIOExtras", "NIO", "NIOTestUtils", "NIOConcurrencyHelpers"]),
     .testTarget(name: "NIOHTTPCompressionTests", dependencies: ["NIOHTTPCompression"]),
 ]
 

--- a/Tests/NIOHTTPCompressionTests/HTTPRequestDecompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPRequestDecompressorTest.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 import CNIOExtrasZlib
-@testable import NIO
+import NIO
 @testable import NIOHTTP1
 @testable import NIOHTTPCompression
 


### PR DESCRIPTION
Motivation:

The test suite for some reason imported NIO as @testable which is
verboten.

Modifications:

Don't do that.

Result:

Feeling better, compatible with the upcoming NIO 2.10.1.