### PR TITLE
WritePCAPHandler: write outbound data on flush not write

### DIFF
--- a/Tests/NIOExtrasTests/WritePCAPHandlerTest+XCTest.swift
+++ b/Tests/NIOExtrasTests/WritePCAPHandlerTest+XCTest.swift
@@ -37,6 +37,8 @@ extension WritePCAPHandlerTest {
                 ("testOversizedInboundDataComesAsTwoPacketsIPv6", testOversizedInboundDataComesAsTwoPacketsIPv6),
                 ("testOversizedOutboundDataComesAsTwoPacketsIPv4", testOversizedOutboundDataComesAsTwoPacketsIPv4),
                 ("testOversizedOutboundDataComesAsTwoPacketsIPv6", testOversizedOutboundDataComesAsTwoPacketsIPv6),
+                ("testUnflushedOutboundDataIsNotWritten", testUnflushedOutboundDataIsNotWritten),
+                ("testDataWrittenAfterCloseIsDiscarded", testDataWrittenAfterCloseIsDiscarded),
            ]
    }
 }


### PR DESCRIPTION
### Motivation:

`NIOWritePCAPHandler` right now writes the outbound data on `write` and not when actually written. In many scenarios, that's okay but it's not as close as it gets to what's sent on the wire.

### Modifications:

Write the data when the write promise succeeds.

### Result:

The emitted `.pcap` is closer to what's actually sent on the wire.