### PR TITLE
NIOWritePCAPHandler: make pcap issuing configurable

### DIFF
--- a/Tests/NIOExtrasTests/WritePCAPHandlerTest+XCTest.swift
+++ b/Tests/NIOExtrasTests/WritePCAPHandlerTest+XCTest.swift
@@ -39,6 +39,7 @@ extension WritePCAPHandlerTest {
                 ("testOversizedOutboundDataComesAsTwoPacketsIPv6", testOversizedOutboundDataComesAsTwoPacketsIPv6),
                 ("testUnflushedOutboundDataIsNotWritten", testUnflushedOutboundDataIsNotWritten),
                 ("testDataWrittenAfterCloseIsDiscarded", testDataWrittenAfterCloseIsDiscarded),
+                ("testUnflushedOutboundDataIsWrittenWhenEmittingWritesOnIssue", testUnflushedOutboundDataIsWrittenWhenEmittingWritesOnIssue),
            ]
    }
 }


### PR DESCRIPTION
### Motivation:

In the past, we would issue the written data immediately on `write` event. As of #74 , we switched to issuing the data when the write completed which reflects what happens on the wire much more closely. We did however notice that in certain cases, the old behaviour is preferable.

### Modifications:

- make the issuing behaviour configurable, defaulting to when the write completes
- make `NIOWritePCAPHandler` removable

### Result:

- more configurability