### PR TITLE
Decompression of HTTP responses that do not contain a Content-Length header

### DIFF
--- a/Sources/NIOHTTPCompression/HTTPDecompression.swift
+++ b/Sources/NIOHTTPCompression/HTTPDecompression.swift
@@ -85,15 +85,15 @@ public enum NIOHTTPDecompression {
             self.limit = limit
         }
 
-        mutating func decompress(part: inout ByteBuffer, buffer: inout ByteBuffer, originalLength: Int) throws {
+        mutating func decompress(part: inout ByteBuffer, buffer: inout ByteBuffer, compressedLength: Int) throws {
             self.inflated += try self.stream.inflatePart(input: &part, output: &buffer)
 
-            if self.limit.exceeded(compressed: originalLength, decompressed: self.inflated) {
+            if self.limit.exceeded(compressed: compressedLength, decompressed: self.inflated) {
                 throw NIOHTTPDecompression.DecompressionError.limit
             }
         }
 
-        mutating func initializeDecoder(encoding: NIOHTTPDecompression.CompressionAlgorithm, length: Int) throws {
+        mutating func initializeDecoder(encoding: NIOHTTPDecompression.CompressionAlgorithm) throws {
             self.stream.zalloc = nil
             self.stream.zfree = nil
             self.stream.opaque = nil

--- a/Sources/NIOHTTPCompression/HTTPRequestDecompressor.swift
+++ b/Sources/NIOHTTPCompression/HTTPRequestDecompressor.swift
@@ -46,7 +46,7 @@ public final class NIOHTTPRequestDecompressor: ChannelDuplexHandler, RemovableCh
                 let length = head.headers[canonicalForm: "Content-Length"].first.flatMap({ Int($0) })
             {
                 do {
-                    try self.decompressor.initializeDecoder(encoding: algorithm, length: length)
+                    try self.decompressor.initializeDecoder(encoding: algorithm)
                     self.compression = Compression(algorithm: algorithm, contentLength: length)
                 } catch let error {
                     context.fireErrorCaught(error)
@@ -64,7 +64,7 @@ public final class NIOHTTPRequestDecompressor: ChannelDuplexHandler, RemovableCh
             while part.readableBytes > 0 {
                 do {
                     var buffer = context.channel.allocator.buffer(capacity: 16384)
-                    try self.decompressor.decompress(part: &part, buffer: &buffer, originalLength: compression.contentLength)
+                    try self.decompressor.decompress(part: &part, buffer: &buffer, compressedLength: compression.contentLength)
 
                     context.fireChannelRead(self.wrapInboundOut(.body(buffer)))
                 } catch let error {

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest+XCTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest+XCTest.swift
@@ -30,6 +30,7 @@ extension HTTPResponseDecompressorTest {
                 ("testDecompressionLimitRatio", testDecompressionLimitRatio),
                 ("testDecompressionLimitSize", testDecompressionLimitSize),
                 ("testDecompression", testDecompression),
+                ("testDecompressionWithoutContentLength", testDecompressionWithoutContentLength),
            ]
    }
 }


### PR DESCRIPTION
### Motivation:

Currently, if the Content-Length header of an HTTP response is missing, the handler won't act on the body data and will directly pass compressed data to the next handlers

### Modifications:

This commit should fix this issue by dynamically updating body size as it reads it when no `Content-Length` header is specified.

### Result:
Fixes #78 
