### PR TITLE
[API breaking] Add types to inbound/outbound debug handlers 

### DIFF
--- a/Sources/NIOExtras/DebugInboundEventsHandler.swift
+++ b/Sources/NIOExtras/DebugInboundEventsHandler.swift
@@ -16,17 +16,17 @@ import NIO
 
 /// ChannelInboundHandler that prints all inbound events that pass through the pipeline by default,
 /// overridable by providing your own closure for custom logging. See DebugOutboundEventsHandler for outbound events.
-public class DebugInboundEventsHandler: ChannelInboundHandler {
+public class DebugInboundEventsHandler<T>: ChannelInboundHandler {
     
-    public typealias InboundIn = Any
-    public typealias InboudOut = Any
+    public typealias InboundIn = T
+    public typealias InboudOut = T
     
     public enum Event {
         case registered
         case unregistered
         case active
         case inactive
-        case read(data: NIOAny)
+        case read(data: T)
         case readComplete
         case writabilityChanged(isWritable: Bool)
         case userInboundEventTriggered(event: Any)
@@ -60,7 +60,7 @@ public class DebugInboundEventsHandler: ChannelInboundHandler {
     }
     
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        logger(.read(data: data), context)
+        logger(.read(data: self.unwrapInboundIn(data)), context)
         context.fireChannelRead(data)
     }
     

--- a/Sources/NIOExtras/DebugOutboundEventsHandler.swift
+++ b/Sources/NIOExtras/DebugOutboundEventsHandler.swift
@@ -16,16 +16,16 @@ import NIO
 
 /// ChannelOutboundHandler that prints all outbound events that pass through the pipeline by default,
 /// overridable by providing your own closure for custom logging. See DebugInboundEventsHandler for inbound events.
-public class DebugOutboundEventsHandler: ChannelOutboundHandler {
+public class DebugOutboundEventsHandler<T>: ChannelOutboundHandler {
     
-    public typealias OutboundIn = Any
-    public typealias OutboundOut = Any
+    public typealias OutboundIn = T
+    public typealias OutboundOut = T
     
     public enum Event {
         case register
         case bind(address: SocketAddress)
         case connect(address: SocketAddress)
-        case write(data: NIOAny)
+        case write(data: T)
         case flush
         case read
         case close(mode: CloseMode)
@@ -54,7 +54,7 @@ public class DebugOutboundEventsHandler: ChannelOutboundHandler {
     }
     
     public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
-        logger(.write(data: data), context)
+        logger(.write(data: self.unwrapOutboundIn(data)), context)
         context.write(data, promise: promise)
     }
     

--- a/Tests/NIOExtrasTests/DebugInboundEventsHandlerTest.swift
+++ b/Tests/NIOExtrasTests/DebugInboundEventsHandlerTest.swift
@@ -19,8 +19,8 @@ import NIOExtras
 class DebugInboundEventsHandlerTest: XCTestCase {
     
     private var channel: EmbeddedChannel!
-    private var lastEvent: DebugInboundEventsHandler.Event!
-    private var handlerUnderTest: DebugInboundEventsHandler!
+    private var lastEvent: DebugInboundEventsHandler<ByteBuffer>.Event!
+    private var handlerUnderTest: DebugInboundEventsHandler<ByteBuffer>!
     
     override func setUp() {
         super.setUp()
@@ -91,7 +91,7 @@ class DebugInboundEventsHandlerTest: XCTestCase {
         expectedBuffer.setString(messageString, at: 0)
         let nioAny = NIOAny(expectedBuffer)
         channel.pipeline.fireChannelRead(nioAny)
-        XCTAssertEqual(lastEvent, .read(data: nioAny))
+        XCTAssertEqual(lastEvent, .read(data: expectedBuffer))
     }
     
 }

--- a/Tests/NIOExtrasTests/DebugOutboundEventsHandlerTest.swift
+++ b/Tests/NIOExtrasTests/DebugOutboundEventsHandlerTest.swift
@@ -19,8 +19,8 @@ import NIOExtras
 class DebugOutboundEventsHandlerTest: XCTestCase {
 
     private var channel: EmbeddedChannel!
-    private var lastEvent: DebugOutboundEventsHandler.Event!
-    private var handlerUnderTest: DebugOutboundEventsHandler!
+    private var lastEvent: DebugOutboundEventsHandler<ByteBuffer>.Event!
+    private var handlerUnderTest: DebugOutboundEventsHandler<ByteBuffer>!
     
     override func setUp() {
         super.setUp()
@@ -56,9 +56,12 @@ class DebugOutboundEventsHandlerTest: XCTestCase {
     }
     
     func testWrite() {
-        let data = NIOAny(" 1 2 3 ")
-        channel.write(data, promise: nil)
-        XCTAssertEqual(lastEvent, .write(data: data))
+        let messageString = "message"
+        var expectedBuffer = ByteBufferAllocator().buffer(capacity: messageString.count)
+        expectedBuffer.setString(messageString, at: 0)
+        let nioAny = NIOAny(expectedBuffer)
+        channel.write(nioAny, promise: nil)
+        XCTAssertEqual(lastEvent, .write(data: expectedBuffer))
     }
     
     func testFlush() {


### PR DESCRIPTION
Add generic types to inbound and outbound debug handlers.

### Motivation:
I've found that the provided debug handlers are not massively useful without types, as it's not possible (as far as I'm aware) to unwrap the data inside NIOAny outside of a channel handler. This means that to debug-print data inside my application I have to essentially recreate the logic provided by the print handlers. This seems redundant, and it would be nice to have an "official" implementation.

### Modifications:
Add generic types `T` to both `Inbound` and `DebugOutboundEventsHandler`. Inside the read event, instead of passing down a `NIOAny`, pass the unwrapped data.

### Result:

_[After your change, what will change.]_

### Notes:
This is an API-breaking change. It's also possible to create new classes, e.g. `TypedDebugInboundEventsHandler`, etc. Alternatively we could cleverly expose something from NIOAny to allow unwrapping outside of a `ChannelHandler`. E.g. `nioAny.unwrap(as: T)`.