### PR TITLE
fix docker setup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 ARG swift_version=5.0
 ARG ubuntu_version=bionic
-FROM swift:$swift_version-$ubuntu_version
+ARG base_image=swift:$swift_version-$ubuntu_version
+FROM $base_image
 # needed to do again after FROM due to docker limitation
 ARG swift_version
 ARG ubuntu_version

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -1,0 +1,16 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-extras:18.04-5.2
+    build:
+      args:
+        ubuntu_version: "bionic"
+        swift_version: "5.2"
+
+  test:
+    image: swift-nio-extras:18.04-5.2
+
+  shell:
+    image: swift-nio-extras:18.04-5.2

--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -1,0 +1,15 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-extras:18.04-5.3
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-master-bionic"
+
+  test:
+    image: swift-nio-extras:18.04-5.3
+
+  shell:
+    image: swift-nio-extras:18.04-5.3

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"
+    command: /bin/bash -xcl "cat /etc/lsb-release && swift -version && swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"
 
   # util
 


### PR DESCRIPTION
Motivation:

We were missing the 5.2 & 5.3 docker compose files and also the syntax
wasn't flexible enough to pull in the new nightlies.

Modifications:

- always specify the full image name
- add 5.2 & 5.3

Result:

More CI & newer Swifts.