### PR TITLE
Let 2020 be an acceptable year in license headers

### DIFF
--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/2017-201[89]/YEARS/' -e 's/2019/YEARS/'
+    sed -e 's/2017-201[89]/YEARS/' -e 's/2019/YEARS/' -e 's/2020/YEARS/g'
 }
 
 printf "=> Checking linux tests... "


### PR DESCRIPTION
Motivation:

It's 2020; our license checking script should believe that that is an
acceptable year.

Modifications:

- Update scripts/sanity.sh

Result:

2020 is okay in license headers.