### PR TITLE
Support decompression of HTTP responses that do not contain a Content…

### DIFF
--- a/Sources/NIOHTTPCompression/HTTPDecompression.swift
+++ b/Sources/NIOHTTPCompression/HTTPDecompression.swift
@@ -46,7 +46,7 @@ public enum NIOHTTPDecompression {
         }
     }
 
-    public enum DecompressionError: Error {
+    public enum DecompressionError: Error, Equatable {
         case limit
         case inflationError(Int)
         case initializationError(Int)
@@ -86,15 +86,15 @@ public enum NIOHTTPDecompression {
             self.limit = limit
         }
 
-        mutating func decompress(part: inout ByteBuffer, buffer: inout ByteBuffer, originalLength: Int) throws {
+        mutating func decompress(part: inout ByteBuffer, buffer: inout ByteBuffer, compressedLength: Int) throws {
             self.inflated += try self.stream.inflatePart(input: &part, output: &buffer)
 
-            if self.limit.exceeded(compressed: originalLength, decompressed: self.inflated) {
+            if self.limit.exceeded(compressed: compressedLength, decompressed: self.inflated) {
                 throw NIOHTTPDecompression.DecompressionError.limit
             }
         }
 
-        mutating func initializeDecoder(encoding: NIOHTTPDecompression.CompressionAlgorithm, length: Int) throws {
+        mutating func initializeDecoder(encoding: NIOHTTPDecompression.CompressionAlgorithm) throws {
             self.stream.zalloc = nil
             self.stream.zfree = nil
             self.stream.opaque = nil

--- a/Sources/NIOHTTPCompression/HTTPRequestDecompressor.swift
+++ b/Sources/NIOHTTPCompression/HTTPRequestDecompressor.swift
@@ -46,7 +46,7 @@ public final class NIOHTTPRequestDecompressor: ChannelDuplexHandler, RemovableCh
                 let length = head.headers[canonicalForm: "Content-Length"].first.flatMap({ Int($0) })
             {
                 do {
-                    try self.decompressor.initializeDecoder(encoding: algorithm, length: length)
+                    try self.decompressor.initializeDecoder(encoding: algorithm)
                     self.compression = Compression(algorithm: algorithm, contentLength: length)
                 } catch let error {
                     context.fireErrorCaught(error)
@@ -64,7 +64,7 @@ public final class NIOHTTPRequestDecompressor: ChannelDuplexHandler, RemovableCh
             while part.readableBytes > 0 {
                 do {
                     var buffer = context.channel.allocator.buffer(capacity: 16384)
-                    try self.decompressor.decompress(part: &part, buffer: &buffer, originalLength: compression.contentLength)
+                    try self.decompressor.decompress(part: &part, buffer: &buffer, compressedLength: compression.contentLength)
 
                     context.fireChannelRead(self.wrapInboundOut(.body(buffer)))
                 } catch let error {

--- a/Sources/NIOHTTPCompression/HTTPResponseDecompressor.swift
+++ b/Sources/NIOHTTPCompression/HTTPResponseDecompressor.swift
@@ -28,7 +28,7 @@ public final class NIOHTTPResponseDecompressor: ChannelDuplexHandler, RemovableC
         var algorithm: NIOHTTPDecompression.CompressionAlgorithm
         
         /// the number of already consumed compressed bytes
-        var compressedLength: Int = 0
+        var compressedLength: Int
     }
 
     private var compression: Compression? = nil
@@ -61,7 +61,7 @@ public final class NIOHTTPResponseDecompressor: ChannelDuplexHandler, RemovableC
 
             do {
                 if let algorithm = algorithm {
-                    self.compression = .init(algorithm: algorithm)
+                    self.compression = Compression(algorithm: algorithm, compressedLength: 0)
                     try self.decompressor.initializeDecoder(encoding: algorithm)
                 }
                 

--- a/Sources/NIOHTTPCompression/HTTPResponseDecompressor.swift
+++ b/Sources/NIOHTTPCompression/HTTPResponseDecompressor.swift
@@ -86,11 +86,11 @@ public final class NIOHTTPResponseDecompressor: ChannelDuplexHandler, RemovableC
 
             context.fireChannelRead(data)
         case .body(var part):
-            self.compression?.compressedLength += part.readableBytes
             switch self.compression {
-            case .some(let compression):
+            case .some(var compression):
+                compression.compressedLength += part.readableBytes
                 while part.readableBytes > 0 {
-                    self.compression?.updateLength(with: part)
+                    compression.updateLength(with: part)
                     var buffer = context.channel.allocator.buffer(capacity: 16384)
                     do {
                         try self.decompressor.decompress(part: &part, buffer: &buffer, compressedLength: compression.compressedLength)

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest+XCTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest+XCTest.swift
@@ -30,6 +30,7 @@ extension HTTPResponseDecompressorTest {
                 ("testDecompressionLimitRatio", testDecompressionLimitRatio),
                 ("testDecompressionLimitSize", testDecompressionLimitSize),
                 ("testDecompression", testDecompression),
+                ("testDecompressionWithoutContentLength", testDecompressionWithoutContentLength),
            ]
    }
 }

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest+XCTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest+XCTest.swift
@@ -27,8 +27,14 @@ extension HTTPResponseDecompressorTest {
    static var allTests : [(String, (HTTPResponseDecompressorTest) -> () throws -> Void)] {
       return [
                 ("testDecompressionNoLimit", testDecompressionNoLimit),
-                ("testDecompressionLimitRatio", testDecompressionLimitRatio),
-                ("testDecompressionLimitSize", testDecompressionLimitSize),
+                ("testDecompressionLimitSizeWithContentLenghtHeaderSucceeds", testDecompressionLimitSizeWithContentLenghtHeaderSucceeds),
+                ("testDecompressionLimitSizeWithContentLenghtHeaderFails", testDecompressionLimitSizeWithContentLenghtHeaderFails),
+                ("testDecompressionLimitSizeWithoutContentLenghtHeaderSucceeds", testDecompressionLimitSizeWithoutContentLenghtHeaderSucceeds),
+                ("testDecompressionLimitSizeWithoutContentLenghtHeaderFails", testDecompressionLimitSizeWithoutContentLenghtHeaderFails),
+                ("testDecompressionLimitRatioWithContentLenghtHeaderSucceeds", testDecompressionLimitRatioWithContentLenghtHeaderSucceeds),
+                ("testDecompressionLimitRatioWithContentLenghtHeaderFails", testDecompressionLimitRatioWithContentLenghtHeaderFails),
+                ("testDecompressionLimitRatioWithoutContentLenghtHeaderSucceeds", testDecompressionLimitRatioWithoutContentLenghtHeaderSucceeds),
+                ("testDecompressionLimitRatioWithoutContentLenghtHeaderFails", testDecompressionLimitRatioWithoutContentLenghtHeaderFails),
                 ("testDecompression", testDecompression),
                 ("testDecompressionWithoutContentLength", testDecompressionWithoutContentLength),
            ]

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest.swift
@@ -237,7 +237,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
 
         XCTAssertNoThrow(try channel.writeInbound(HTTPClientResponsePart.end(nil)))
     }
-    
+
     private func compress(_ body: ByteBuffer, _ algorithm: String) -> ByteBuffer {
         var stream = z_stream()
 

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest.swift
@@ -34,24 +34,18 @@ class HTTPResponseDecompressorTest: XCTestCase {
         let channel = EmbeddedChannel()
         try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .ratio(10))).wait()
 
-        let headers = HTTPHeaders([("Content-Encoding", "deflate"), ("Content-Length", "13")])
-        try channel.writeInbound(HTTPClientResponsePart.head(.init(version: .init(major: 1, minor: 1), status: .ok, headers: headers)))
+        let headersArray = [
+            HTTPHeaders([("Content-Encoding", "deflate"), ("Content-Length", "13")]),
+            HTTPHeaders([("Content-Encoding", "deflate")])
+        ]
+        
+        for headers in headersArray {
+            try channel.writeInbound(HTTPClientResponsePart.head(.init(version: .init(major: 1, minor: 1), status: .ok, headers: headers)))
 
-        let body = ByteBuffer.of(bytes: [120, 156, 75, 76, 28, 5, 200, 0, 0, 248, 66, 103, 17])
-
-        do {
-            try channel.writeInbound(HTTPClientResponsePart.body(body))
-            XCTFail("writeInbound should fail")
-        } catch let error as NIOHTTPDecompression.DecompressionError {
-            switch error {
-            case .limit:
-                // ok
-                break
-            default:
-                XCTFail("Unexptected error: \(error)")
+            let body = ByteBuffer.of(bytes: [120, 156, 75, 76, 28, 5, 200, 0, 0, 248, 66, 103, 17])
+            XCTAssertThrowsError(try channel.writeInbound(HTTPClientResponsePart.body(body))) { error in
+                XCTAssertEqual(error as? NIOHTTPDecompression.DecompressionError, .limit)
             }
-        } catch {
-            XCTFail("Unexptected error: \(error)")
         }
     }
 
@@ -59,24 +53,18 @@ class HTTPResponseDecompressorTest: XCTestCase {
         let channel = EmbeddedChannel()
         try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .size(15))).wait()
 
-        let headers = HTTPHeaders([("Content-Encoding", "deflate"), ("Content-Length", "13")])
-        try channel.writeInbound(HTTPClientResponsePart.head(.init(version: .init(major: 1, minor: 1), status: .ok, headers: headers)))
+        let headersArray = [
+            HTTPHeaders([("Content-Encoding", "deflate"), ("Content-Length", "13")]),
+            HTTPHeaders([("Content-Encoding", "deflate")])
+        ]
+        
+        for headers in headersArray {
+            try channel.writeInbound(HTTPClientResponsePart.head(.init(version: .init(major: 1, minor: 1), status: .ok, headers: headers)))
 
-        let body = ByteBuffer.of(bytes: [120, 156, 75, 76, 28, 5, 200, 0, 0, 248, 66, 103, 17])
-
-        do {
-            try channel.writeInbound(HTTPClientResponsePart.body(body))
-            XCTFail("writeInbound should fail")
-        } catch let error as NIOHTTPDecompression.DecompressionError {
-            switch error {
-            case .limit:
-                // ok
-                break
-            default:
-                XCTFail("Unexptected error: \(error)")
+            let body = ByteBuffer.of(bytes: [120, 156, 75, 76, 28, 5, 200, 0, 0, 248, 66, 103, 17])
+            XCTAssertThrowsError(try channel.writeInbound(HTTPClientResponsePart.body(body))) { error in
+                XCTAssertEqual(error as? NIOHTTPDecompression.DecompressionError, .limit)
             }
-        } catch {
-            XCTFail("Unexptected error: \(error)")
         }
     }
 
@@ -106,7 +94,46 @@ class HTTPResponseDecompressorTest: XCTestCase {
 
         XCTAssertNoThrow(try channel.writeInbound(HTTPClientResponsePart.end(nil)))
     }
+    
+    func testDecompressionWithoutContentLength() throws {
+        let channel = EmbeddedChannel()
+        try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .none)).wait()
 
+        let expectedBody = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+
+        for algorithm in [nil, "gzip", "deflate"] {
+            let compressed: ByteBuffer
+            var headers = HTTPHeaders()
+            if let algorithm = algorithm {
+                headers.add(name: "Content-Encoding", value: algorithm)
+                compressed = compress(ByteBuffer.of(string: expectedBody), algorithm)
+            } else {
+                compressed = ByteBuffer.of(string: expectedBody)
+            }
+
+            XCTAssertNoThrow(try channel.writeInbound(HTTPClientResponsePart.head(.init(version: .init(major: 1, minor: 1), status: .ok, headers: headers))))
+            XCTAssertNoThrow(try channel.writeInbound(HTTPClientResponsePart.body(compressed)))
+            
+            XCTAssertNoThrow(try channel.readInbound(as: Any.self))
+            
+            
+            if case .body(let buffer) = try channel.readInbound(as: HTTPClientResponsePart.self) {
+                let bodyData = Data(buffer.readableBytesView)
+                guard let bodyString = String(data: bodyData, encoding: .utf8) else {
+                    XCTFail("Impossible to decode string decompressed from algorithm: \(algorithm ?? "non-compressed")")
+                    return
+                }
+                
+                XCTAssertEqual(bodyString, expectedBody, "Decompressed string not equal to expected result from algorithm \(algorithm ?? "non-compressed")")
+                
+            } else {
+                XCTFail("Unexpected response part")
+            }
+        }
+
+        XCTAssertNoThrow(try channel.writeInbound(HTTPClientResponsePart.end(nil)))
+    }
+    
     private func compress(_ body: ByteBuffer, _ algorithm: String) -> ByteBuffer {
         var stream = z_stream()
 


### PR DESCRIPTION
This builds on top of #79.

- Rebased (Changed test structure to use `XCTAssertThrowsError`)
- Addressed @Lukasa's review comments

Original PR message from @adtrevor:

### Motivation:

Currently, if the Content-Length header of an HTTP response is missing, the handler won't act on the body data and will directly pass compressed data to the next handlers

### Modifications:

This commit should fix this issue by dynamically updating body size as it reads it when no Content-Length header is specified.

### Result:

Fixes #78