### PR TITLE
Fix #file warnings

### DIFF
--- a/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
+++ b/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
@@ -61,7 +61,8 @@ class WritePCAPHandlerTest: XCTestCase {
     func assertEqual(expectedAddress: SocketAddress?,
                      actualIPv4Address: in_addr,
                      actualPort: UInt16,
-                     file: StaticString = #file,
+                     file: StaticString = (#file)
+                     ,
                      line: UInt = #line) {
         guard let port = expectedAddress?.port else {
             XCTFail("expected address nil or has no port", file: file, line: line)
@@ -82,7 +83,7 @@ class WritePCAPHandlerTest: XCTestCase {
     func assertEqual(expectedAddress: SocketAddress?,
                      actualIPv6Address: in6_addr,
                      actualPort: UInt16,
-                     file: StaticString = #file,
+                     file: StaticString = (#file),
                      line: UInt = #line) {
         guard let port = expectedAddress?.port else {
             XCTFail("expected address nil or has no port", file: file, line: line)

--- a/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
+++ b/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
@@ -61,8 +61,7 @@ class WritePCAPHandlerTest: XCTestCase {
     func assertEqual(expectedAddress: SocketAddress?,
                      actualIPv4Address: in_addr,
                      actualPort: UInt16,
-                     file: StaticString = (#file)
-                     ,
+                     file: StaticString = (#file),
                      line: UInt = #line) {
         guard let port = expectedAddress?.port else {
             XCTFail("expected address nil or has no port", file: file, line: line)

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
@@ -28,7 +28,7 @@ private class PromiseOrderer {
         self.eventLoop = eventLoop
     }
 
-    func makePromise(file: StaticString = #file, line: UInt = #line) -> EventLoopPromise<Void> {
+    func makePromise(file: StaticString = (#file), line: UInt = #line) -> EventLoopPromise<Void> {
         let promise = eventLoop.makePromise(of: Void.self, file: file, line: line)
         appendPromise(promise)
         return promise


### PR DESCRIPTION
Replace all usages of `#file` with `(#file)`

### Motivation:

Warnings were present when running the tests.

### Modifications:

Silence the warnings by wrapping in parentheses.

### Result:

No more warnings.
