### PR TITLE
Silence #file warnings

### DIFF
--- a/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
+++ b/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
@@ -61,7 +61,7 @@ class WritePCAPHandlerTest: XCTestCase {
     func assertEqual(expectedAddress: SocketAddress?,
                      actualIPv4Address: in_addr,
                      actualPort: UInt16,
-                     file: StaticString = (#file),
+                     file: StaticString = #file,
                      line: UInt = #line) {
         guard let port = expectedAddress?.port else {
             XCTFail("expected address nil or has no port", file: (file), line: line)
@@ -82,7 +82,7 @@ class WritePCAPHandlerTest: XCTestCase {
     func assertEqual(expectedAddress: SocketAddress?,
                      actualIPv6Address: in6_addr,
                      actualPort: UInt16,
-                     file: StaticString = (#file),
+                     file: StaticString = #file,
                      line: UInt = #line) {
         guard let port = expectedAddress?.port else {
             XCTFail("expected address nil or has no port", file: (file), line: line)

--- a/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
+++ b/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
@@ -64,7 +64,7 @@ class WritePCAPHandlerTest: XCTestCase {
                      file: StaticString = (#file),
                      line: UInt = #line) {
         guard let port = expectedAddress?.port else {
-            XCTFail("expected address nil or has no port", file: file, line: line)
+            XCTFail("expected address nil or has no port", file: (file), line: line)
             return
         }
         switch expectedAddress {
@@ -72,10 +72,10 @@ class WritePCAPHandlerTest: XCTestCase {
             XCTAssertEqual(expectedAddress.address.sin_addr.s_addr,
                            actualIPv4Address.s_addr,
                            "IP addresses don't match",
-                           file: file, line: line)
-            XCTAssertEqual(port, Int(actualPort), "ports don't match", file: file, line: line)
+                           file: (file), line: line)
+            XCTAssertEqual(port, Int(actualPort), "ports don't match", file: (file), line: line)
         default:
-            XCTFail("expected address not an IPv4 address", file: file, line: line)
+            XCTFail("expected address not an IPv4 address", file: (file), line: line)
         }
     }
 
@@ -85,7 +85,7 @@ class WritePCAPHandlerTest: XCTestCase {
                      file: StaticString = (#file),
                      line: UInt = #line) {
         guard let port = expectedAddress?.port else {
-            XCTFail("expected address nil or has no port", file: file, line: line)
+            XCTFail("expected address nil or has no port", file: (file), line: line)
             return
         }
         switch expectedAddress {
@@ -97,9 +97,9 @@ class WritePCAPHandlerTest: XCTestCase {
                     XCTAssertEqual(actualAddressBytes.count, expectedAddressBytes.count)
                 }
             }
-            XCTAssertEqual(port, Int(actualPort), "ports don't match", file: file, line: line)
+            XCTAssertEqual(port, Int(actualPort), "ports don't match", file: (file), line: line)
         default:
-            XCTFail("expected address not an IPv4 address", file: file, line: line)
+            XCTFail("expected address not an IPv4 address", file: (file), line: line)
         }
     }
 

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
@@ -29,7 +29,7 @@ private class PromiseOrderer {
     }
 
     func makePromise(file: StaticString = (#file), line: UInt = #line) -> EventLoopPromise<Void> {
-        let promise = eventLoop.makePromise(of: Void.self, file: file, line: line)
+        let promise = eventLoop.makePromise(of: Void.self, file: (file), line: line)
         appendPromise(promise)
         return promise
     }

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
@@ -28,7 +28,7 @@ private class PromiseOrderer {
         self.eventLoop = eventLoop
     }
 
-    func makePromise(file: StaticString = (#file), line: UInt = #line) -> EventLoopPromise<Void> {
+    func makePromise(file: StaticString = #file, line: UInt = #line) -> EventLoopPromise<Void> {
         let promise = eventLoop.makePromise(of: Void.self, file: (file), line: line)
         appendPromise(promise)
         return promise


### PR DESCRIPTION
Follow up of #96, but uses the suggested fix this time inside the call, instead of the declaration.