### PR TITLE
Ensures gzip/deflate-compressed responses are properly finalized in all cases

### DIFF
--- a/Sources/NIOHTTPCompression/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTPCompression/HTTPResponseCompressor.swift
@@ -280,7 +280,7 @@ private struct PartialHTTPResponse {
     /// buffer and losing all copies of the other HTTP data. At this point it may freely be reused.
     mutating func flush(compressor: inout NIOCompression.Compressor, allocator: ByteBufferAllocator) -> (HTTPResponseHead?, ByteBuffer?, HTTPServerResponsePart?) {
         var outputBody: ByteBuffer? = nil
-        if self.body.readableBytes > 0 {
+        if self.body.readableBytes > 0 || mustFlush {
             let compressedBody = compressor.compress(inputBuffer: &self.body, allocator: allocator, finalise: mustFlush)
             if isCompleteResponse {
                 head!.headers.remove(name: "transfer-encoding")

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest+XCTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest+XCTest.swift
@@ -44,6 +44,7 @@ extension HTTPResponseCompressorTest {
                 ("testOverridesContentEncodingHeader", testOverridesContentEncodingHeader),
                 ("testRemovingHandlerFailsPendingWrites", testRemovingHandlerFailsPendingWrites),
                 ("testDoesNotBufferWritesNoAlgorithm", testDoesNotBufferWritesNoAlgorithm),
+                ("testChunkedGzipResponseProducesCorrectNumberOfWrites", testChunkedGzipResponseProducesCorrectNumberOfWrites),
                 ("testStartsWithSameUnicodeScalarsWorksOnEmptyStrings", testStartsWithSameUnicodeScalarsWorksOnEmptyStrings),
                 ("testStartsWithSameUnicodeScalarsWorksOnLongerNeedleFalse", testStartsWithSameUnicodeScalarsWorksOnLongerNeedleFalse),
                 ("testStartsWithSameUnicodeScalarsWorksOnSameStrings", testStartsWithSameUnicodeScalarsWorksOnSameStrings),

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
@@ -554,8 +554,8 @@ class HTTPResponseCompressorTest: XCTestCase {
         var bodyBuffer = channel.allocator.buffer(capacity: 20)
         bodyBuffer.writeBytes([UInt8](repeating: 60, count: 20))
 
-        _ = channel.write(NIOAny(HTTPServerResponsePart.head(head)))
-        _ = channel.writeAndFlush(NIOAny(HTTPServerResponsePart.body(.byteBuffer(bodyBuffer))))
+        channel.write(NIOAny(HTTPServerResponsePart.head(head)), promise: nil)
+        channel.writeAndFlush(NIOAny(HTTPServerResponsePart.body(.byteBuffer(bodyBuffer))), promise: nil)
         channel.writeAndFlush(NIOAny(HTTPServerResponsePart.end(nil)), promise: finalPromise)
         
         try finalPromise.futureResult.wait()
@@ -565,6 +565,15 @@ class HTTPResponseCompressorTest: XCTestCase {
             writeCount += 1
         }
         
+        // Expected number of emitted writes in the chunked response is 8:
+        //   1. HTTP response header
+        //   2. First chunk length
+        //   3. First chunk body
+        //   4. CRLF
+        //   5. Second chunk length
+        //   6. Second chunk body
+        //   7. CRLF
+        //   8. End of message chunk
         XCTAssertEqual(writeCount, 8)
     }
 

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
@@ -545,6 +545,28 @@ class HTTPResponseCompressorTest: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.removeHandler(name: "compressor").wait())
         XCTAssertNoThrow(try writePromise.futureResult.wait())
     }
+    
+    func testChunkedGzipResponseProducesCorrectNumberOfWrites() throws {
+        let channel = try compressionChannel()
+        try sendRequest(acceptEncoding: "gzip", channel: channel)
+        let finalPromise = channel.eventLoop.makePromise(of: Void.self)
+        let head = HTTPResponseHead(version: HTTPVersion(major: 1, minor: 1), status: .ok)
+        var bodyBuffer = channel.allocator.buffer(capacity: 20)
+        bodyBuffer.writeBytes([UInt8](repeating: 60, count: 20))
+
+        _ = channel.write(NIOAny(HTTPServerResponsePart.head(head)))
+        _ = channel.writeAndFlush(NIOAny(HTTPServerResponsePart.body(.byteBuffer(bodyBuffer))))
+        channel.writeAndFlush(NIOAny(HTTPServerResponsePart.end(nil)), promise: finalPromise)
+        
+        try finalPromise.futureResult.wait()
+        
+        var writeCount = 0
+        while try channel.readOutbound(as: ByteBuffer.self) != nil {
+            writeCount += 1
+        }
+        
+        XCTAssertEqual(writeCount, 8)
+    }
 
     func testStartsWithSameUnicodeScalarsWorksOnEmptyStrings() throws {
         XCTAssertTrue("".startsWithSameUnicodeScalars(string: ""))


### PR DESCRIPTION
Fixes #99.

Please check if the test makes sense like this – It would also be possible to implement this write order as a `WriteStrategy` for `compressResponse()` and detect the erroneous handling in `decompress()` later.

### Motivation:

Previously, when using the response compressor, doing a flush() right before finishing the
response data would cause the final compression chunk to be omitted. Some strict decompressors
(such as gzip or the zlib functionality exported in nodejs) would refuse to decompress the
incomplete response.

With this change, the generated compressed response is properly finalized.

### Modifications:

In HTTPResponseCompressor.swift, a channel write is now also generated if no body data is
added, but a flush is required.

### Result:

The response is now correct for this edge case, enabling gzip, nodejs, et al., to
decompress it without errors.