### PR TITLE
Optimise "startsWithSameUnicodeScalars", fix documentation

### DIFF
--- a/Sources/NIOHTTPCompression/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTPCompression/HTTPResponseCompressor.swift
@@ -17,15 +17,15 @@ import NIO
 import NIOHTTP1
 
 extension StringProtocol {
-    /// Test if this `Collection` starts with the unicode scalars of `needle`.
+    /// Test if this string starts with the same unicode scalars as the given string, `prefix`.
     ///
     /// - note: This will be faster than `String.startsWith` as no unicode normalisations are performed.
     ///
     /// - parameters:
-    ///    - needle: The `Collection` of `Unicode.Scalar`s to match at the beginning of `self`
-    /// - returns: If `self` started with the elements contained in `needle`.
-    func startsWithSameUnicodeScalars<S: StringProtocol>(string needle: S) -> Bool {
-        return self.unicodeScalars.starts(with: needle.unicodeScalars)
+    ///    - prefix: The string to match at the beginning of `self`
+    /// - returns: Whether or not `self` starts with the same unicode scalars as `prefix`.
+    func startsWithExactly<S: StringProtocol>(_ prefix: S) -> Bool {
+        return self.utf8.starts(with: prefix.utf8)
     }
 }
 
@@ -155,11 +155,11 @@ public final class HTTPResponseCompressor: ChannelDuplexHandler, RemovableChanne
         var anyQValue: Float = -1
 
         for acceptHeader in acceptHeaders {
-            if acceptHeader.startsWithSameUnicodeScalars(string: "gzip") || acceptHeader.startsWithSameUnicodeScalars(string: "x-gzip") {
+            if acceptHeader.startsWithExactly("gzip") || acceptHeader.startsWithExactly("x-gzip") {
                 gzipQValue = qValueFromHeader(acceptHeader)
-            } else if acceptHeader.startsWithSameUnicodeScalars(string: "deflate") {
+            } else if acceptHeader.startsWithExactly("deflate") {
                 deflateQValue = qValueFromHeader(acceptHeader)
-            } else if acceptHeader.startsWithSameUnicodeScalars(string: "*") {
+            } else if acceptHeader.startsWithExactly("*") {
                 anyQValue = qValueFromHeader(acceptHeader)
             }
         }

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
@@ -578,19 +578,19 @@ class HTTPResponseCompressorTest: XCTestCase {
     }
 
     func testStartsWithSameUnicodeScalarsWorksOnEmptyStrings() throws {
-        XCTAssertTrue("".startsWithSameUnicodeScalars(string: ""))
+        XCTAssertTrue("".startsWithExactly(""))
     }
 
     func testStartsWithSameUnicodeScalarsWorksOnLongerNeedleFalse() throws {
-        XCTAssertFalse("_".startsWithSameUnicodeScalars(string: "__"))
+        XCTAssertFalse("_".startsWithExactly("__"))
     }
 
     func testStartsWithSameUnicodeScalarsWorksOnSameStrings() throws {
-        XCTAssertTrue("beer".startsWithSameUnicodeScalars(string: "beer"))
+        XCTAssertTrue("beer".startsWithExactly("beer"))
     }
 
     func testStartsWithSameUnicodeScalarsWorksOnPrefix() throws {
-        XCTAssertTrue("beer is good".startsWithSameUnicodeScalars(string: "beer"))
+        XCTAssertTrue("beer is good".startsWithExactly("beer"))
     }
 
     func testStartsWithSameUnicodeScalarsSaysNoForTheSameStringInDifferentNormalisations() throws {
@@ -598,11 +598,11 @@ class HTTPResponseCompressorTest: XCTestCase {
         let nfdEncodedEAigu = "\u{65}\u{301}"
 
         XCTAssertEqual(nfcEncodedEAigu, nfdEncodedEAigu)
-        XCTAssertTrue(nfcEncodedEAigu.startsWithSameUnicodeScalars(string: nfcEncodedEAigu))
-        XCTAssertTrue(nfdEncodedEAigu.startsWithSameUnicodeScalars(string: nfdEncodedEAigu))
+        XCTAssertTrue(nfcEncodedEAigu.startsWithExactly(nfcEncodedEAigu))
+        XCTAssertTrue(nfdEncodedEAigu.startsWithExactly(nfdEncodedEAigu))
         // the both do _not_ start like the other
-        XCTAssertFalse(nfcEncodedEAigu.startsWithSameUnicodeScalars(string: nfdEncodedEAigu))
-        XCTAssertFalse(nfdEncodedEAigu.startsWithSameUnicodeScalars(string: nfcEncodedEAigu))
+        XCTAssertFalse(nfcEncodedEAigu.startsWithExactly(nfdEncodedEAigu))
+        XCTAssertFalse(nfdEncodedEAigu.startsWithExactly(nfcEncodedEAigu))
     }
 
     func testStartsWithSaysYesForTheSameStringInDifferentNormalisations() throws {


### PR DESCRIPTION
We don't need to bother decoding unicode scalars out of the strings: if we're not doing any normalisation, we can can just compare the scalars in their UTF8-encoded form. While I'm at it, use `StaticString` since this is only used to test for literals such as "gzip".

### Motivation:

Small optimisation.

### Modifications:

See above. Also, the previous documentation was wrong, talking about generic collections of `Unicode.Scalar`s.

### Result:

Code which uses this utility function should be a bit more efficient.
