### PR TITLE
Skip HTTPResponseCompressor logic if response is 204 (no content)

### DIFF
--- a/Sources/NIOHTTPCompression/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTPCompression/HTTPResponseCompressor.swift
@@ -106,7 +106,7 @@ public final class HTTPResponseCompressor: ChannelDuplexHandler, RemovableChanne
         let httpData = unwrapOutboundIn(data)
         switch httpData {
         case .head(var responseHead):
-            guard let algorithm = compressionAlgorithm(), responseHead.status != .noContent else {
+            guard let algorithm = compressionAlgorithm(), responseHead.status.mayHaveResponseBody else {
                 context.write(wrapOutboundOut(.head(responseHead)), promise: promise)
                 return
             }

--- a/Sources/NIOHTTPCompression/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTPCompression/HTTPResponseCompressor.swift
@@ -106,7 +106,7 @@ public final class HTTPResponseCompressor: ChannelDuplexHandler, RemovableChanne
         let httpData = unwrapOutboundIn(data)
         switch httpData {
         case .head(var responseHead):
-            guard let algorithm = compressionAlgorithm() else {
+            guard let algorithm = compressionAlgorithm(), responseHead.status != .noContent else {
                 context.write(wrapOutboundOut(.head(responseHead)), promise: promise)
                 return
             }

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest+XCTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest+XCTest.swift
@@ -52,6 +52,7 @@ extension HTTPResponseCompressorTest {
                 ("testStartsWithSameUnicodeScalarsSaysNoForTheSameStringInDifferentNormalisations", testStartsWithSameUnicodeScalarsSaysNoForTheSameStringInDifferentNormalisations),
                 ("testStartsWithSaysYesForTheSameStringInDifferentNormalisations", testStartsWithSaysYesForTheSameStringInDifferentNormalisations),
                 ("testCanBeRemoved", testCanBeRemoved),
+                ("testBypassCompressionWhenNoContent", testBypassCompressionWhenNoContent),
            ]
    }
 }


### PR DESCRIPTION
Disables HTTPResponseCompressor compression if response is 204 no content

### Motivation:

Related to https://github.com/vapor/vapor/issues/2464. I've attempted to solve this in https://github.com/vapor/vapor/pull/2465 by stripping any `content-encoding` headers returned in route handlers, but this obviously has no effect on HTTPResponseCompressor which runs _after_ Vapor's handlers. I could add a handler to the end of the chain that sanitizes the headers again, but this seems overkill. HTTPResponseCompressor should probably be the one doing this check.

### Modifications:

Adds a check to HTTPResponseCompressor to see if the response is 204 no content before engaging the compression logic.

### Result:

HTTPResponseCompressor will no longer compress the response if it is 204 no content. 
