### PR TITLE
Fail outstanding promises in `channelInactive` in the `RequestResponseHandler`

### DIFF
--- a/Sources/NIOExtras/NIOExtrasError.swift
+++ b/Sources/NIOExtras/NIOExtrasError.swift
@@ -22,4 +22,7 @@ public enum NIOExtrasErrors {
     public struct LeftOverBytesError: NIOExtrasError {
         public let leftOverBytes: ByteBuffer
     }
+
+    /// The channel was closed before receiving a response to a request.
+    public struct ClosedBeforeReceivingResponse: NIOExtrasError {}
 }

--- a/Tests/NIOExtrasTests/RequestResponseHandlerTest+XCTest.swift
+++ b/Tests/NIOExtrasTests/RequestResponseHandlerTest+XCTest.swift
@@ -30,6 +30,7 @@ extension RequestResponseHandlerTest {
                 ("testEnqueingMultipleRequestsWorks", testEnqueingMultipleRequestsWorks),
                 ("testRequestsEnqueuedAfterErrorAreFailed", testRequestsEnqueuedAfterErrorAreFailed),
                 ("testRequestsEnqueuedJustBeforeErrorAreFailed", testRequestsEnqueuedJustBeforeErrorAreFailed),
+                ("testClosedConnectionFailsOutstandingPromises", testClosedConnectionFailsOutstandingPromises),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

It's possible for channels to be closed without an error; and the
`RequestResponseHandler` should tolerate that by failing any promises
for which it does not have a response for.

Modifications:

- Add `ClosedBeforeReceivingResponseError`
- Fail outstanding promises with `ClosedBeforeReceivingResponseError` in
  `RequestResponseHandler.channelInactive`
- Add a test.

Result:

Outstanding request promises are failed when the channel becomes inactive.