### PR TITLE
Forward 'channelInactive' in the RequestResponseHandler

### DIFF
--- a/Sources/NIOExtras/RequestResponseHandler.swift
+++ b/Sources/NIOExtras/RequestResponseHandler.swift
@@ -72,6 +72,7 @@ public final class RequestResponseHandler<Request, Response>: ChannelDuplexHandl
                 promise.fail(NIOExtrasErrors.ClosedBeforeReceivingResponse())
             }
         }
+        context.fireChannelInactive()
     }
 
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {


### PR DESCRIPTION
Motivation:

As a rule of thumb we should always forward channel events to the next
handler. #106 added an implementation for `channelInactive` but forgot
to forward it.

Modifications:

- forward `channelInactive` in the `RequestResponseHandler`

Result:

Handlers after the `RequestResponseHandler` will recieve
`channelInactive`.