### PR TITLE
Add watchOS deployment to PodSpec build script

### DIFF
--- a/scripts/build_podspec.sh
+++ b/scripts/build_podspec.sh
@@ -77,6 +77,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
+  s.watchos.deployment_target = '6.0'
 
   s.dependency 'SwiftNIO', '>= $nio_version', '< $next_major_version'
 


### PR DESCRIPTION
Motivation:

We support watchOS 6+ with SwiftNIO Transport Services; as such we should
include watchOS as a deployment target for our CocoaPods.

Modifications:

- Add a watchOS deployment target to `build_podspecs.sh`

Result:

Users can deploy to watchOS 6+ with CocoaPods.