### PR TITLE
fix crash in LengthFieldBasedFrameDecoder for malicious length values

### DIFF
--- a/Sources/NIOExtras/LengthFieldBasedFrameDecoder.swift
+++ b/Sources/NIOExtras/LengthFieldBasedFrameDecoder.swift
@@ -88,11 +88,6 @@ public final class LengthFieldBasedFrameDecoder: ByteToMessageDecoder {
     ///    - lengthFieldEndianness: The endianness of the field specifying the remaining length of the frame.
     ///
     public init(lengthFieldLength: ByteLength, lengthFieldEndianness: Endianness = .big) {
-
-        // The value contained in the length field must be able to be represented by an integer type on the platform.
-        // ie. .eight == 64bit which would not fit into the Int type on a 32bit platform.
-        precondition(lengthFieldLength.length <= Int.bitWidth/8)
-            
         self.lengthFieldLength = lengthFieldLength
         self.lengthFieldEndianness = lengthFieldEndianness
     }

--- a/Sources/NIOExtras/LengthFieldBasedFrameDecoder.swift
+++ b/Sources/NIOExtras/LengthFieldBasedFrameDecoder.swift
@@ -190,7 +190,7 @@ public final class LengthFieldBasedFrameDecoder: ByteToMessageDecoder {
         
         if let frameLength = frameLength,
            frameLength > Self.maxSupportedLengthFieldSize {
-            throw LengthFieldBasedFrameDecoderError.lengthFieldValueTooLarge
+            throw LengthFieldBasedFrameDecoderError.lengthFieldValueLargerThanMaxSupportedSize
         }
         return frameLength
     }

--- a/Sources/NIOExtras/LengthFieldBasedFrameDecoder.swift
+++ b/Sources/NIOExtras/LengthFieldBasedFrameDecoder.swift
@@ -14,7 +14,7 @@
 
 import NIO
 
-public enum LengthFieldBasedFrameDecoderError: Error {
+public enum NIOLengthFieldBasedFrameDecoderError: Error {
     /// This error can be thrown by `LengthFieldBasedFrameDecoder` if the length field value is larger than `Int.max`
     case lengthFieldValueTooLarge
     /// This error can be thrown by `LengthFieldBasedFrameDecoder` if the length field value is larger than `LengthFieldBasedFrameDecoder.maxSupportedLengthFieldSize`
@@ -41,7 +41,7 @@ public enum LengthFieldBasedFrameDecoderError: Error {
 ///
 public final class LengthFieldBasedFrameDecoder: ByteToMessageDecoder {
     /// Maximum supported length field size in bytes of `LengthFieldBasedFrameDecoder` and is currently `Int32.max`
-    static let maxSupportedLengthFieldSize: Int = Int(Int32.max)
+    public static let maxSupportedLengthFieldSize: Int = Int(Int32.max)
     ///
     /// An enumeration to describe the length of a piece of data in bytes.
     /// It is contained to lengths that can be converted to integer types.
@@ -175,22 +175,22 @@ public final class LengthFieldBasedFrameDecoder: ByteToMessageDecoder {
         case .four:
             frameLength = try buffer.readInteger(endianness: self.lengthFieldEndianness, as: UInt32.self).map {
                 guard let size = Int(exactly: $0) else {
-                    throw LengthFieldBasedFrameDecoderError.lengthFieldValueTooLarge
+                    throw NIOLengthFieldBasedFrameDecoderError.lengthFieldValueTooLarge
                 }
                 return size
             }
         case .eight:
             frameLength = try buffer.readInteger(endianness: self.lengthFieldEndianness, as: UInt64.self).map {
                 guard let size = Int(exactly: $0) else {
-                    throw LengthFieldBasedFrameDecoderError.lengthFieldValueTooLarge
+                    throw NIOLengthFieldBasedFrameDecoderError.lengthFieldValueTooLarge
                 }
                 return size
             }
         }
         
         if let frameLength = frameLength,
-           frameLength > Self.maxSupportedLengthFieldSize {
-            throw LengthFieldBasedFrameDecoderError.lengthFieldValueLargerThanMaxSupportedSize
+           frameLength > LengthFieldBasedFrameDecoder.maxSupportedLengthFieldSize {
+            throw NIOLengthFieldBasedFrameDecoderError.lengthFieldValueLargerThanMaxSupportedSize
         }
         return frameLength
     }

--- a/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest+XCTest.swift
+++ b/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest+XCTest.swift
@@ -42,7 +42,9 @@ extension LengthFieldBasedFrameDecoderTest {
                 ("testRemoveHandlerWhenBufferIsNotEmpty", testRemoveHandlerWhenBufferIsNotEmpty),
                 ("testCloseInChannelRead", testCloseInChannelRead),
                 ("testBasicVerification", testBasicVerification),
+                ("testMaximumAllowedLengthWith32BitFieldLength", testMaximumAllowedLengthWith32BitFieldLength),
                 ("testMaliciousLengthWith32BitFieldLength", testMaliciousLengthWith32BitFieldLength),
+                ("testMaximumAllowedLengthWith64BitFieldLength", testMaximumAllowedLengthWith64BitFieldLength),
                 ("testMaliciousLengthWith64BitFieldLength", testMaliciousLengthWith64BitFieldLength),
            ]
    }

--- a/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest+XCTest.swift
+++ b/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest+XCTest.swift
@@ -42,8 +42,8 @@ extension LengthFieldBasedFrameDecoderTest {
                 ("testRemoveHandlerWhenBufferIsNotEmpty", testRemoveHandlerWhenBufferIsNotEmpty),
                 ("testCloseInChannelRead", testCloseInChannelRead),
                 ("testBasicVerification", testBasicVerification),
-                ("testMaliciousLengthOn32BitPlatform", testMaliciousLengthOn32BitPlatform),
-                ("testMaliciousLengthOn64BitPlatform", testMaliciousLengthOn64BitPlatform),
+                ("testMaliciousLengthWith32BitFieldLength", testMaliciousLengthWith32BitFieldLength),
+                ("testMaliciousLengthWith64BitFieldLength", testMaliciousLengthWith64BitFieldLength),
            ]
    }
 }

--- a/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest+XCTest.swift
+++ b/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest+XCTest.swift
@@ -42,6 +42,8 @@ extension LengthFieldBasedFrameDecoderTest {
                 ("testRemoveHandlerWhenBufferIsNotEmpty", testRemoveHandlerWhenBufferIsNotEmpty),
                 ("testCloseInChannelRead", testCloseInChannelRead),
                 ("testBasicVerification", testBasicVerification),
+                ("testMaliciousLengthOn32BitPlatform", testMaliciousLengthOn32BitPlatform),
+                ("testMaliciousLengthOn64BitPlatform", testMaliciousLengthOn64BitPlatform),
            ]
    }
 }

--- a/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest.swift
+++ b/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest.swift
@@ -461,7 +461,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                                                                    lengthFieldEndianness: .little))
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
 
-        let dataLength: UInt32 = UInt32(Int32.max) + 1
+        let dataLength = UInt32(Int32.max) + 1
         
         var buffer = self.channel.allocator.buffer(capacity: 4) // 4 byte header
         buffer.writeInteger(dataLength, endianness: .little, as: UInt32.self)
@@ -475,13 +475,11 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
     }
     
     func testMaliciousLengthOn64BitPlatform() {
-        // LengthFieldBasedFrameDecoder.ByteLength.eight is only supported on 64 bit systems
-        guard UInt64.bitWidth == UInt.bitWidth else { return }
         self.decoderUnderTest = .init(LengthFieldBasedFrameDecoder(lengthFieldLength: .eight,
                                                                    lengthFieldEndianness: .little))
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
 
-        let dataLength: UInt64 = UInt64(Int64.max) + 1
+        let dataLength = UInt64(Int64.max) + 1
         
         var buffer = self.channel.allocator.buffer(capacity: 8) // 8 byte header
         buffer.writeInteger(dataLength, endianness: .little, as: UInt64.self)

--- a/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest.swift
+++ b/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest.swift
@@ -474,8 +474,9 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         }
     }
     
-    func testMaliciousLengthOn64BitPlatform() throws {
-        try XCTSkipIf(UInt64.bitWidth != UInt.bitWidth) // LengthFieldBasedFrameDecoder.ByteLength.eight is only supported on 64 bit systems
+    func testMaliciousLengthOn64BitPlatform() {
+        // LengthFieldBasedFrameDecoder.ByteLength.eight is only supported on 64 bit systems
+        guard UInt64.bitWidth == UInt.bitWidth else { return }
         self.decoderUnderTest = .init(LengthFieldBasedFrameDecoder(lengthFieldLength: .eight,
                                                                    lengthFieldEndianness: .little))
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())

--- a/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest.swift
+++ b/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest.swift
@@ -466,12 +466,8 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         var buffer = self.channel.allocator.buffer(capacity: 4) // 4 byte header
         buffer.writeInteger(dataLength, endianness: .little, as: UInt32.self)
         buffer.writeString(standardDataString)
-        if UInt32.bitWidth == UInt.bitWidth {
-            // LengthFieldBasedFrameDecoder.ByteLength.four should only throw if we are on a 32 bit platform
-            XCTAssertThrowsError(try self.channel.writeInbound(buffer))
-        } else {
-            XCTAssertFalse(try self.channel.writeInbound(buffer).isFull)
-        }
+        
+        XCTAssertThrowsError(try self.channel.writeInbound(buffer))
     }
     
     func testMaliciousLengthOn64BitPlatform() {

--- a/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest.swift
+++ b/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest.swift
@@ -456,7 +456,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         }
     }
     
-    func testMaliciousLengthOn32BitPlatform() throws {
+    func testMaliciousLengthWith32BitFieldLength() throws {
         self.decoderUnderTest = .init(LengthFieldBasedFrameDecoder(lengthFieldLength: .four,
                                                                    lengthFieldEndianness: .little))
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
@@ -470,7 +470,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         XCTAssertThrowsError(try self.channel.writeInbound(buffer))
     }
     
-    func testMaliciousLengthOn64BitPlatform() {
+    func testMaliciousLengthWith64BitFieldLength() {
         self.decoderUnderTest = .init(LengthFieldBasedFrameDecoder(lengthFieldLength: .eight,
                                                                    lengthFieldEndianness: .little))
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())

--- a/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest.swift
+++ b/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest.swift
@@ -455,6 +455,19 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
             })
         }
     }
+    func testMaximumAllowedLengthWith32BitFieldLength() throws {
+        self.decoderUnderTest = .init(LengthFieldBasedFrameDecoder(lengthFieldLength: .four,
+                                                                   lengthFieldEndianness: .little))
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+
+        let dataLength = UInt32(Int32.max)
+        
+        var buffer = self.channel.allocator.buffer(capacity: 4) // 4 byte header
+        buffer.writeInteger(dataLength, endianness: .little, as: UInt32.self)
+        buffer.writeString(standardDataString)
+        
+        XCTAssertNoThrow(try self.channel.writeInbound(buffer))
+    }
     
     func testMaliciousLengthWith32BitFieldLength() throws {
         self.decoderUnderTest = .init(LengthFieldBasedFrameDecoder(lengthFieldLength: .four,
@@ -470,12 +483,26 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
         XCTAssertThrowsError(try self.channel.writeInbound(buffer))
     }
     
+    func testMaximumAllowedLengthWith64BitFieldLength() throws {
+        self.decoderUnderTest = .init(LengthFieldBasedFrameDecoder(lengthFieldLength: .eight,
+                                                                   lengthFieldEndianness: .little))
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+
+        let dataLength = UInt64(Int32.max)
+        
+        var buffer = self.channel.allocator.buffer(capacity: 8) // 8 byte header
+        buffer.writeInteger(dataLength, endianness: .little, as: UInt64.self)
+        buffer.writeString(standardDataString)
+        
+        XCTAssertNoThrow(try self.channel.writeInbound(buffer))
+    }
+    
     func testMaliciousLengthWith64BitFieldLength() {
         self.decoderUnderTest = .init(LengthFieldBasedFrameDecoder(lengthFieldLength: .eight,
                                                                    lengthFieldEndianness: .little))
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
 
-        let dataLength = UInt64(Int64.max) + 1
+        let dataLength = UInt64(Int32.max) + 1
         
         var buffer = self.channel.allocator.buffer(capacity: 8) // 8 byte header
         buffer.writeInteger(dataLength, endianness: .little, as: UInt64.self)


### PR DESCRIPTION
### Motivation:

LengthFieldBasedFrameDecoder will cause a fatal error if the length value does not fit into an `Int`.
This can happen if `lengthFieldLength` is set to `.eight` and we are on a 64 bit platform or if `lengthFieldLength` is set to `.four` and we are on a 32-bit platform.
If we then receive a length field value which is greater than `Int.max` the conversion from `UInt` to `Int` will cause a fatal error.
This could be abused to crash a server by only sending 4 or 8 bytes.

### Modifications:

safely convert UInt64 & UInt32 to Int and throw an error if they can't be represented as an Int

### Result:

- LengthFieldBasedFrameDecoder with lengthFieldLength set to `.eight` can no longer crash the server on a 64-bit platform
- LengthFieldBasedFrameDecoder with lengthFieldLength set to `.four` can no longer crash the server on a 32-bit platform
