### PR TITLE
Fix Swift 5.4 docker setup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev build-esse
 # switch off gem docs building
 RUN echo "gem: --no-document" > ~/.gemrc
 # jazzy no longer works on xenial as ruby is too old.
-RUN if [ "${ubuntu_version}" != "xenial" ] ; then  gem install jazzy --no-ri --no-rdoc ; fi
+RUN if [ "${ubuntu_version}" != "xenial" ] ; then  gem install jazzy; fi
 
 # tools
 RUN mkdir -p $HOME/.tools


### PR DESCRIPTION
Motivation:

Docker build for Swift 5.4 is failing with:

```
18:27:28 ERROR:  While executing gem ... (OptionParser::InvalidOption)
18:27:28     invalid option: --no-ri
18:27:28 Did you mean?  no-force
```

Modifications:
Remove `--no-ri --no-rdoc`.

Result:
Docker build for Swift 5.4 completes successfully.
