### PR TITLE
Add Swift 5.5 nightly configuration

### DIFF
--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -1,0 +1,16 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-extras:20.04-5.5
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-5.5-focal"
+        ubuntu_version: "focal"
+
+  test:
+    image: swift-nio-extras:20.04-5.5
+
+  shell:
+    image: swift-nio-extras:20.04-5.5


### PR DESCRIPTION
Use the nightly Swift 5.5 image for running the 5.5 tests. Currently the tests fail instantly because the docker compose file is missing.