### PR TITLE
Fix SOCKS client sending greeting and port/address endianness

### DIFF
--- a/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
+++ b/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
@@ -99,7 +99,7 @@ public final class SOCKSClientHandler: ChannelDuplexHandler {
 extension SOCKSClientHandler {
     
     private func beginHandshake(context: ChannelHandlerContext) {
-        guard self.state.shouldBeginHandshake else {
+        guard context.channel.isActive, self.state.shouldBeginHandshake else {
             return
         }
         do {

--- a/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
+++ b/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
@@ -99,7 +99,7 @@ public final class SOCKSClientHandler: ChannelDuplexHandler {
 extension SOCKSClientHandler {
     
     private func beginHandshake(context: ChannelHandlerContext) {
-        guard context.channel.isActive,  self.state.shouldBeginHandshake else {
+        guard context.channel.isActive, self.state.shouldBeginHandshake else {
             return
         }
         do {

--- a/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
+++ b/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
@@ -99,7 +99,7 @@ public final class SOCKSClientHandler: ChannelDuplexHandler {
 extension SOCKSClientHandler {
     
     private func beginHandshake(context: ChannelHandlerContext) {
-        guard context.channel.isActive, self.state.shouldBeginHandshake else {
+        guard context.channel.isActive,  self.state.shouldBeginHandshake else {
             return
         }
         do {

--- a/Sources/NIOSOCKS/Messages/SOCKSRequest.swift
+++ b/Sources/NIOSOCKS/Messages/SOCKSRequest.swift
@@ -175,12 +175,12 @@ extension ByteBuffer {
         switch type {
         case .address(.v4(let address)):
             return self.writeInteger(SOCKSAddress.ipv4IdentifierByte)
-                + self.writeInteger(address.address.sin_addr.s_addr)
-                + self.writeInteger(address.address.sin_port)
+                + self.writeIPv4Address(address.address)
+                + self.writeInteger(UInt16(bigEndian: address.address.sin_port))
         case .address(.v6(let address)):
             return self.writeInteger(SOCKSAddress.ipv6IdentifierByte)
                 + self.writeIPv6Address(address.address)
-                + self.writeInteger(address.address.sin6_port)
+                + self.writeInteger(UInt16(bigEndian: address.address.sin6_port))
         case .address(.unixDomainSocket):
             // enforced in the channel initalisers.
             fatalError("UNIX domain sockets are not supported")
@@ -194,6 +194,12 @@ extension ByteBuffer {
     
     @discardableResult mutating func writeIPv6Address(_ addr: sockaddr_in6) -> Int {
         return withUnsafeBytes(of: addr.sin6_addr) { pointer in
+            return self.writeBytes(pointer)
+        }
+    }
+    
+    @discardableResult mutating func writeIPv4Address(_ addr: sockaddr_in) -> Int {
+        return withUnsafeBytes(of: addr.sin_addr) { pointer in
             return self.writeBytes(pointer)
         }
     }

--- a/Sources/NIOSOCKSClient/main.swift
+++ b/Sources/NIOSOCKSClient/main.swift
@@ -24,7 +24,7 @@ class EchoHandler: ChannelInboundHandler {
     
 }
 
-let targetIPAddress = "192.168.1.2"
+let targetIPAddress = "127.0.0.1"
 let targetPort = 12345
 let targetAddress = SOCKSAddress.address(try SocketAddress(ipAddress: targetIPAddress, port: targetPort))
 

--- a/Tests/NIOSOCKSTests/ClientRequest+Tests.swift
+++ b/Tests/NIOSOCKSTests/ClientRequest+Tests.swift
@@ -29,7 +29,7 @@ extension ClientRequestTests {
         XCTAssertEqual(buffer.writeClientRequest(req), 10)
         XCTAssertEqual(buffer.readableBytes, 10)
         XCTAssertEqual(buffer.readBytes(length: 10)!,
-                       [0x05, 0x01, 0x00, 1, 1, 1, 168, 192, 0x50, 0])
+                       [0x05, 0x01, 0x00, 1, 192, 168, 1, 1, 0x00, 0x50])
     }
     
 }
@@ -58,13 +58,13 @@ extension ClientRequestTests {
     func testWriteAddressType(){
         var ipv4 = ByteBuffer()
         XCTAssertEqual(ipv4.writeAddressType(.address(try! .init(ipAddress: "192.168.1.1", port: 80))), 7)
-        XCTAssertEqual(ipv4.readBytes(length: 5)!, [1, 1, 1, 168, 192])
-        XCTAssertEqual(ipv4.readInteger(as: UInt16.self)!, 0x5000)
+        XCTAssertEqual(ipv4.readBytes(length: 5)!, [1, 192, 168, 1, 1])
+        XCTAssertEqual(ipv4.readInteger(as: UInt16.self)!, 0x0050)
         
         var ipv6 = ByteBuffer()
         XCTAssertEqual(ipv6.writeAddressType(.address(try! .init(ipAddress: "0001:0002:0003:0004:0005:0006:0007:0008", port: 80))), 19)
         XCTAssertEqual(ipv6.readBytes(length: 17)!, [4, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8])
-        XCTAssertEqual(ipv6.readInteger(as: UInt16.self)!, 0x5000)
+        XCTAssertEqual(ipv6.readInteger(as: UInt16.self)!, 0x0050)
     }
     
 }

--- a/Tests/NIOSOCKSTests/ClientRequest+Tests.swift
+++ b/Tests/NIOSOCKSTests/ClientRequest+Tests.swift
@@ -59,12 +59,12 @@ extension ClientRequestTests {
         var ipv4 = ByteBuffer()
         XCTAssertEqual(ipv4.writeAddressType(.address(try! .init(ipAddress: "192.168.1.1", port: 80))), 7)
         XCTAssertEqual(ipv4.readBytes(length: 5)!, [1, 192, 168, 1, 1])
-        XCTAssertEqual(ipv4.readInteger(as: UInt16.self)!, 0x0050)
+        XCTAssertEqual(ipv4.readInteger(as: UInt16.self)!, 80)
         
         var ipv6 = ByteBuffer()
         XCTAssertEqual(ipv6.writeAddressType(.address(try! .init(ipAddress: "0001:0002:0003:0004:0005:0006:0007:0008", port: 80))), 19)
         XCTAssertEqual(ipv6.readBytes(length: 17)!, [4, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8])
-        XCTAssertEqual(ipv6.readInteger(as: UInt16.self)!, 0x0050)
+        XCTAssertEqual(ipv6.readInteger(as: UInt16.self)!, 80)
     }
     
 }

--- a/Tests/NIOSOCKSTests/SocksClientHandler+Tests+XCTest.swift
+++ b/Tests/NIOSOCKSTests/SocksClientHandler+Tests+XCTest.swift
@@ -30,6 +30,7 @@ extension SocksClientHandlerTests {
                 ("testTypicalWorkflowDripfeed", testTypicalWorkflowDripfeed),
                 ("testInvalidAuthenticationMethod", testInvalidAuthenticationMethod),
                 ("testProxyConnectionFailed", testProxyConnectionFailed),
+                ("testDelayedConnection", testDelayedConnection),
            ]
    }
 }

--- a/Tests/NIOSOCKSTests/SocksClientHandler+Tests+XCTest.swift
+++ b/Tests/NIOSOCKSTests/SocksClientHandler+Tests+XCTest.swift
@@ -31,6 +31,7 @@ extension SocksClientHandlerTests {
                 ("testInvalidAuthenticationMethod", testInvalidAuthenticationMethod),
                 ("testProxyConnectionFailed", testProxyConnectionFailed),
                 ("testDelayedConnection", testDelayedConnection),
+                ("testDelayedHandlerAdded", testDelayedHandlerAdded),
            ]
    }
 }

--- a/Tests/NIOSOCKSTests/SocksClientHandler+Tests.swift
+++ b/Tests/NIOSOCKSTests/SocksClientHandler+Tests.swift
@@ -63,7 +63,7 @@ class SocksClientHandlerTests: XCTestCase {
         self.writeInbound([0x05, 0x00])
         
         // client sends the request
-        self.assertOutputBuffer([0x05, 0x01, 0x00, 0x01, 1, 1, 168, 192, 0x50, 0x00])
+        self.assertOutputBuffer([0x05, 0x01, 0x00, 0x01, 192, 168, 1, 1, 0x00, 0x50])
         
         // server replies yay or nay
         self.writeInbound([0x05, 0x00, 0x00, 0x01, 192, 168, 1, 1, 0x00, 0x50])
@@ -85,7 +85,7 @@ class SocksClientHandlerTests: XCTestCase {
         self.writeInbound([0x05])
         self.assertOutputBuffer([])
         self.writeInbound([0x00])
-        self.assertOutputBuffer([0x05, 0x01, 0x00, 0x01, 1, 1, 168, 192, 0x50, 0x00])
+        self.assertOutputBuffer([0x05, 0x01, 0x00, 0x01, 192, 168, 1, 1, 0x00, 0x50])
         
         // drip feed server response
         self.writeInbound([0x05, 0x00, 0x00, 0x01])
@@ -149,7 +149,7 @@ class SocksClientHandlerTests: XCTestCase {
         // start handshake, send request
         self.assertOutputBuffer([0x05, 0x01, 0x00])
         self.writeInbound([0x05, 0x00])
-        self.assertOutputBuffer([0x05, 0x01, 0x00, 0x01, 1, 1, 168, 192, 0x50, 0x00])
+        self.assertOutputBuffer([0x05, 0x01, 0x00, 0x01, 192, 168, 1, 1, 0x00, 0x50])
         
         // server replies with an error
         let promise = self.channel.eventLoop.makePromise(of: Void.self)


### PR DESCRIPTION
The SOCKS client doesn't work in its current state. The client channel handler may be added upon channel creation, or later. To accommodate for this we attempt to begin the handshake in both `channelActive` and `handlerAdded`. `handlerAdded` is always called first, but if the handler is added before the channel is active then the client greeting will fail, and the state machine will enter an irrecoverable error state.

~This wasn't caught by the tests as the tests use an `EmbeddedChannel`, where the channel is always active.~

Modifications:
Guard the channel active state.