### PR TITLE
Fix incorrect SOCKS client flushing behaviour

### DIFF
--- a/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
+++ b/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
@@ -79,8 +79,11 @@ public final class SOCKSClientHandler: ChannelDuplexHandler {
     }
     
     public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
-        let buffer = self.unwrapOutboundIn(data)
-        self.bufferedWrites.append((data, promise))
+        if self.state.proxyEstablished {
+            context.write(data, promise: promise)
+        } else {
+            self.bufferedWrites.append((data, promise))
+        }
     }
     
     private func writeBufferedData(context: ChannelHandlerContext) {

--- a/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
+++ b/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
@@ -79,7 +79,7 @@ public final class SOCKSClientHandler: ChannelDuplexHandler {
     }
     
     public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
-        if self.state.proxyEstablished {
+        if self.state.proxyEstablished && self.bufferedWrites.count == 0 {
             context.write(data, promise: promise)
         } else {
             self.bufferedWrites.append((data, promise))

--- a/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
+++ b/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
@@ -92,6 +92,7 @@ public final class SOCKSClientHandler: ChannelDuplexHandler {
             let (data, promise) = self.bufferedWrites.removeFirst()
             context.write(data, promise: promise)
         }
+        context.flush()
     }
     
 }

--- a/Tests/NIOSOCKSTests/SocksClientHandler+Tests+XCTest.swift
+++ b/Tests/NIOSOCKSTests/SocksClientHandler+Tests+XCTest.swift
@@ -27,6 +27,8 @@ extension SocksClientHandlerTests {
    static var allTests : [(String, (SocksClientHandlerTests) -> () throws -> Void)] {
       return [
                 ("testTypicalWorkflow", testTypicalWorkflow),
+                ("testThatBufferingWorks", testThatBufferingWorks),
+                ("testBufferingWithMark", testBufferingWithMark),
                 ("testTypicalWorkflowDripfeed", testTypicalWorkflowDripfeed),
                 ("testInvalidAuthenticationMethod", testInvalidAuthenticationMethod),
                 ("testProxyConnectionFailed", testProxyConnectionFailed),

--- a/Tests/NIOSOCKSTests/SocksClientHandler+Tests.swift
+++ b/Tests/NIOSOCKSTests/SocksClientHandler+Tests.swift
@@ -71,7 +71,27 @@ class SocksClientHandlerTests: XCTestCase {
         // any inbound data should now go straight through
         self.writeInbound([1, 2, 3, 4, 5])
         self.assertInbound([1, 2, 3, 4, 5])
+
+        // any outbound data should also go straight through
+        XCTAssertNoThrow(try self.channel.writeOutbound(ByteBuffer(bytes: [1, 2, 3, 4, 5])))
+        self.assertOutputBuffer([1, 2, 3, 4, 5])
+    }
+    
+    // Tests that if we write alot of data at the start then
+    // that data will be written after the client has completed
+    // the socks handshake.
+    func testThatBufferingWorks() {
+        self.connect()
         
+        let writePromise = self.channel.eventLoop.makePromise(of: Void.self)
+        self.channel.writeAndFlush(ByteBuffer(bytes: [1, 2, 3, 4, 5]), promise: writePromise)
+        self.assertOutputBuffer([0x05, 0x01, 0x00])
+        self.writeInbound([0x05, 0x00])
+        self.assertOutputBuffer([0x05, 0x01, 0x00, 0x01, 192, 168, 1, 1, 0x00, 0x50])
+        self.writeInbound([0x05, 0x00, 0x00, 0x01, 192, 168, 1, 1, 0x00, 0x50])
+        
+        XCTAssertNoThrow(try writePromise.futureResult.wait())
+        self.assertOutputBuffer([1, 2, 3, 4, 5])
     }
     
     func testTypicalWorkflowDripfeed() {


### PR DESCRIPTION
Use a `MarkedCircularBuffer` to track pending writes while the SOCKS handshake has not yet completed.

### Motivation:

Data wasn't flushed properly in some cases.

### Modifications:

Use a marked circular buffer to mark on flush, and then write up until that mark when flushing occurs. Also added regression tests.
