### PR TITLE
Add SOCKS authentication fast path

### DIFF
--- a/Sources/NIOSOCKS/Channel Handlers/SOCKSServerHandshakeHandler.swift
+++ b/Sources/NIOSOCKS/Channel Handlers/SOCKSServerHandshakeHandler.swift
@@ -114,7 +114,7 @@ public final class SOCKSServerHandshakeHandler: ChannelDuplexHandler, RemovableC
             if !self.stateMachine.isAuthenticated {
                 try self.stateMachine.authenticationComplete()
             }
-            promise?.succeed(())
+            context.write(data, promise: promise)
             return
         }
         

--- a/Sources/NIOSOCKS/Channel Handlers/SOCKSServerHandshakeHandler.swift
+++ b/Sources/NIOSOCKS/Channel Handlers/SOCKSServerHandshakeHandler.swift
@@ -69,16 +69,20 @@ public final class SOCKSServerHandshakeHandler: ChannelDuplexHandler, RemovableC
     }
     
     public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let message = self.unwrapOutboundIn(data)
+        let outboundBuffer: ByteBuffer
+        
         do {
-            let message = self.unwrapOutboundIn(data)
             switch message {
             case .selectedAuthenticationMethod(let method):
-                try self.handleWriteSelectedAuthenticationMethod(method, context: context, promise: promise)
+                outboundBuffer = try self.handleWriteSelectedAuthenticationMethod(method, context: context)
             case .response(let response):
-                try self.handleWriteResponse(response, context: context, promise: promise)
+                outboundBuffer = try self.handleWriteResponse(response, context: context)
             case .authenticationData(let data, let complete):
-                try self.handleWriteAuthenticationData(data, complete: complete, context: context, promise: promise)
+                outboundBuffer = try self.handleWriteAuthenticationData(data, complete: complete, context: context)
             }
+            context.write(self.wrapOutboundOut(outboundBuffer), promise: promise)
+            
         } catch {
             context.fireErrorCaught(error)
             promise?.fail(error)
@@ -86,24 +90,25 @@ public final class SOCKSServerHandshakeHandler: ChannelDuplexHandler, RemovableC
     }
     
     private func handleWriteSelectedAuthenticationMethod(
-        _ method: SelectedAuthenticationMethod, context: ChannelHandlerContext, promise: EventLoopPromise<Void>?) throws {
+        _ method: SelectedAuthenticationMethod, context: ChannelHandlerContext) throws -> ByteBuffer {
         try stateMachine.sendAuthenticationMethod(method)
         var buffer = context.channel.allocator.buffer(capacity: 16)
         buffer.writeMethodSelection(method)
-        context.write(self.wrapOutboundOut(buffer), promise: promise)
+        return buffer
     }
     
     private func handleWriteResponse(
-        _ response: SOCKSResponse, context: ChannelHandlerContext, promise: EventLoopPromise<Void>?) throws {
+        _ response: SOCKSResponse, context: ChannelHandlerContext) throws -> ByteBuffer {
         try stateMachine.sendServerResponse(response)
         var buffer = context.channel.allocator.buffer(capacity: 16)
         buffer.writeServerResponse(response)
-        context.write(self.wrapOutboundOut(buffer), promise: promise)
+        return buffer
     }
     
-    private func handleWriteAuthenticationData(_ data: ByteBuffer, complete: Bool, context: ChannelHandlerContext, promise: EventLoopPromise<Void>?) throws {
+    private func handleWriteAuthenticationData(
+        _ data: ByteBuffer, complete: Bool, context: ChannelHandlerContext) throws -> ByteBuffer {
         try self.stateMachine.sendAuthenticationData(data, complete: complete)
-        context.write(self.wrapOutboundOut(data), promise: promise)
+        return data
     }
     
 }

--- a/Sources/NIOSOCKS/Channel Handlers/SOCKSServerHandshakeHandler.swift
+++ b/Sources/NIOSOCKS/Channel Handlers/SOCKSServerHandshakeHandler.swift
@@ -69,10 +69,9 @@ public final class SOCKSServerHandshakeHandler: ChannelDuplexHandler, RemovableC
     }
     
     public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
-        let message = self.unwrapOutboundIn(data)
-        let outboundBuffer: ByteBuffer
-        
         do {
+            let message = self.unwrapOutboundIn(data)
+            let outboundBuffer: ByteBuffer
             switch message {
             case .selectedAuthenticationMethod(let method):
                 outboundBuffer = try self.handleWriteSelectedAuthenticationMethod(method, context: context)

--- a/Sources/NIOSOCKS/Channel Handlers/SOCKSServerHandshakeHandler.swift
+++ b/Sources/NIOSOCKS/Channel Handlers/SOCKSServerHandshakeHandler.swift
@@ -91,12 +91,6 @@ public final class SOCKSServerHandshakeHandler: ChannelDuplexHandler, RemovableC
         var buffer = context.channel.allocator.buffer(capacity: 16)
         buffer.writeMethodSelection(method)
         context.write(self.wrapOutboundOut(buffer), promise: promise)
-        
-        // fast path to check if authentication can be marked as complete
-        // only applies when there is no authentication
-        if method.method == .noneRequired {
-            try self.handleWriteAuthenticationData(context.channel.allocator.buffer(capacity: 0), complete: true, context: context, promise: nil)
-        }
     }
     
     private func handleWriteResponse(
@@ -108,20 +102,7 @@ public final class SOCKSServerHandshakeHandler: ChannelDuplexHandler, RemovableC
     }
     
     private func handleWriteAuthenticationData(_ data: ByteBuffer, complete: Bool, context: ChannelHandlerContext, promise: EventLoopPromise<Void>?) throws {
-        
-        // fast path to check if we can automatically mark authentication as complete
-        if data.readableBytes == 0 && complete {
-            if !self.stateMachine.isAuthenticated {
-                try self.stateMachine.authenticationComplete()
-            }
-            context.write(data, promise: promise)
-            return
-        }
-        
-        try self.stateMachine.sendData()
-        if complete {
-            try self.stateMachine.authenticationComplete()
-        }
+        try self.stateMachine.sendAuthenticationData(data, complete: complete)
         context.write(self.wrapOutboundOut(data), promise: promise)
     }
     

--- a/Sources/NIOSOCKS/State/ServerStateMachine.swift
+++ b/Sources/NIOSOCKS/State/ServerStateMachine.swift
@@ -44,6 +44,15 @@ struct ServerStateMachine: Hashable {
         }
     }
     
+    var isAuthenticated: Bool {
+        switch self.state {
+        case .inactive, .waitingForClientGreeting, .waitingToSendAuthenticationMethod, .authenticating, .error:
+            return false
+        case .waitingForClientRequest, .waitingToSendResponse, .active:
+            return true
+        }
+    }
+    
     init() {
         self.state = .inactive
     }

--- a/Sources/NIOSOCKS/State/ServerStateMachine.swift
+++ b/Sources/NIOSOCKS/State/ServerStateMachine.swift
@@ -28,6 +28,7 @@ enum ServerState: Hashable {
 struct ServerStateMachine: Hashable {
     
     private var state: ServerState
+    private var authenticationMethod: AuthenticationMethod?
     
     var proxyEstablished: Bool {
         switch self.state {
@@ -41,15 +42,6 @@ struct ServerStateMachine: Hashable {
              .waitingToSendResponse,
              .error:
             return false
-        }
-    }
-    
-    var isAuthenticated: Bool {
-        switch self.state {
-        case .inactive, .waitingForClientGreeting, .waitingToSendAuthenticationMethod, .authenticating, .error:
-            return false
-        case .waitingForClientRequest, .waitingToSendResponse, .active:
-            return true
         }
     }
     
@@ -127,7 +119,7 @@ extension ServerStateMachine {
         self.state = .waitingForClientGreeting
     }
     
-    mutating func sendAuthenticationMethod(_ method: SelectedAuthenticationMethod) throws {
+    mutating func sendAuthenticationMethod(_ selected: SelectedAuthenticationMethod) throws {
         switch self.state {
         case .waitingToSendAuthenticationMethod:
             ()
@@ -140,7 +132,13 @@ extension ServerStateMachine {
              .error:
              throw SOCKSError.InvalidServerState()
         }
-        self.state = .authenticating
+        
+        self.authenticationMethod = selected.method
+        if selected.method == .noneRequired {
+            self.state = .waitingForClientRequest
+        } else {
+            self.state = .authenticating
+        }
     }
     
     mutating func sendServerResponse(_ response: SOCKSResponse) throws {
@@ -164,35 +162,25 @@ extension ServerStateMachine {
         }
     }
     
-    mutating func sendData() throws {
+    mutating func sendAuthenticationData(_ data: ByteBuffer, complete: Bool) throws {
         switch self.state {
         case .authenticating:
-            ()
+            break
+        case .waitingForClientRequest:
+            guard self.authenticationMethod == .noneRequired, complete, data.readableBytes == 0 else {
+                throw SOCKSError.InvalidServerState()
+            }
         case .inactive,
              .waitingForClientGreeting,
              .waitingToSendAuthenticationMethod,
-             .waitingForClientRequest,
-             .waitingToSendResponse,
-             .active,
-             .error:
-             throw SOCKSError.InvalidServerState()
-        }
-    }
-    
-    mutating func authenticationComplete() throws {
-        switch self.state {
-        case .authenticating:
-            ()
-        case .inactive,
-             .waitingForClientGreeting,
-             .waitingToSendAuthenticationMethod,
-             .waitingForClientRequest,
              .waitingToSendResponse,
              .active,
              .error:
              throw SOCKSError.InvalidServerState()
         }
         
-        self.state = .waitingForClientRequest
+        if complete {
+            self.state = .waitingForClientRequest
+        }
     }
 }

--- a/Tests/NIOSOCKSTests/SOCKSServerHandshakeHandler+Tests+XCTest.swift
+++ b/Tests/NIOSOCKSTests/SOCKSServerHandshakeHandler+Tests+XCTest.swift
@@ -36,6 +36,7 @@ extension SOCKSServerHandlerTests {
                 ("testAutoAuthenticationCompleteWithManualCompletion", testAutoAuthenticationCompleteWithManualCompletion),
                 ("testEagerClientRequestBeforeAuthenticationComplete", testEagerClientRequestBeforeAuthenticationComplete),
                 ("testManualAuthenticationFailureExtraBytes", testManualAuthenticationFailureExtraBytes),
+                ("testManualAuthenticationFailureInvalidCompletion", testManualAuthenticationFailureInvalidCompletion),
            ]
    }
 }

--- a/Tests/NIOSOCKSTests/SOCKSServerHandshakeHandler+Tests+XCTest.swift
+++ b/Tests/NIOSOCKSTests/SOCKSServerHandshakeHandler+Tests+XCTest.swift
@@ -32,6 +32,8 @@ extension SOCKSServerHandlerTests {
                 ("testOutboundErrorsAreHandled", testOutboundErrorsAreHandled),
                 ("testFlushOnHandlerRemoved", testFlushOnHandlerRemoved),
                 ("testForceHandlerRemovalAfterAuth", testForceHandlerRemovalAfterAuth),
+                ("testAutoAuthentictionComplete", testAutoAuthentictionComplete),
+                ("testAutoAuthentictionCompleteWithManuallyCompletion", testAutoAuthentictionCompleteWithManuallyCompletion),
            ]
    }
 }

--- a/Tests/NIOSOCKSTests/SOCKSServerHandshakeHandler+Tests+XCTest.swift
+++ b/Tests/NIOSOCKSTests/SOCKSServerHandshakeHandler+Tests+XCTest.swift
@@ -32,9 +32,10 @@ extension SOCKSServerHandlerTests {
                 ("testOutboundErrorsAreHandled", testOutboundErrorsAreHandled),
                 ("testFlushOnHandlerRemoved", testFlushOnHandlerRemoved),
                 ("testForceHandlerRemovalAfterAuth", testForceHandlerRemovalAfterAuth),
-                ("testAutoAuthentictionComplete", testAutoAuthentictionComplete),
-                ("testAutoAuthentictionCompleteWithManuallyCompletion", testAutoAuthentictionCompleteWithManuallyCompletion),
+                ("testAutoAuthenticationComplete", testAutoAuthenticationComplete),
+                ("testAutoAuthenticationCompleteWithManualCompletion", testAutoAuthenticationCompleteWithManualCompletion),
                 ("testEagerClientRequestBeforeAuthenticationComplete", testEagerClientRequestBeforeAuthenticationComplete),
+                ("testManualAuthenticationFailureExtraBytes", testManualAuthenticationFailureExtraBytes),
            ]
    }
 }

--- a/Tests/NIOSOCKSTests/SOCKSServerHandshakeHandler+Tests+XCTest.swift
+++ b/Tests/NIOSOCKSTests/SOCKSServerHandshakeHandler+Tests+XCTest.swift
@@ -34,6 +34,7 @@ extension SOCKSServerHandlerTests {
                 ("testForceHandlerRemovalAfterAuth", testForceHandlerRemovalAfterAuth),
                 ("testAutoAuthentictionComplete", testAutoAuthentictionComplete),
                 ("testAutoAuthentictionCompleteWithManuallyCompletion", testAutoAuthentictionCompleteWithManuallyCompletion),
+                ("testEagerClientRequestBeforeAuthenticationComplete", testEagerClientRequestBeforeAuthenticationComplete),
            ]
    }
 }

--- a/Tests/NIOSOCKSTests/SOCKSServerHandshakeHandler+Tests.swift
+++ b/Tests/NIOSOCKSTests/SOCKSServerHandshakeHandler+Tests.swift
@@ -176,8 +176,7 @@ class SOCKSServerHandlerTests: XCTestCase {
         XCTAssertNoThrow(try self.channel.writeOutbound(ServerMessage.selectedAuthenticationMethod(.init(method: .gssapi))))
         self.assertOutputBuffer([0x05, 0x01])
         
-        // finish authentication - nothing should be written
-        // as this is informing the state machine only
+        // finish authentication with some bytes
         XCTAssertNoThrow(try self.channel.writeOutbound(ServerMessage.authenticationData(ByteBuffer(bytes: [0xFF, 0xFF]), complete: true)))
         self.assertOutputBuffer([0xFF, 0xFF])
         
@@ -220,7 +219,8 @@ class SOCKSServerHandlerTests: XCTestCase {
         self.writeInbound([0x05, 0x01, 0x01])
         self.writeOutbound(.selectedAuthenticationMethod(.init(method: .gssapi)))
         self.assertOutputBuffer([0x05, 0x01])
-        XCTAssertNoThrow(try self.handler.stateMachine.authenticationComplete())
+        self.writeOutbound(.authenticationData(ByteBuffer(), complete: true))
+        self.assertOutputBuffer([])
         self.writeInbound([0x05, 0x01, 0x00, 0x01, 127, 0, 0, 1, 0, 80])
         self.writeOutbound(.response(.init(reply: .succeeded, boundAddress: .address(try! .init(ipAddress: "127.0.0.1", port: 80)))))
         self.assertOutputBuffer([0x05, 0x00, 0x00, 0x01, 127, 0, 0, 1, 0, 80])

--- a/Tests/NIOSOCKSTests/SOCKSServerHandshakeHandler+Tests.swift
+++ b/Tests/NIOSOCKSTests/SOCKSServerHandshakeHandler+Tests.swift
@@ -294,7 +294,7 @@ class SOCKSServerHandlerTests: XCTestCase {
         self.assertOutputBuffer([0x05, 0x00])
         
         // invalid authentication completion
-        // we've selection `noneRequired`, so no
+        // we've selected `noneRequired`, so no
         // bytes should be written
         XCTAssertThrowsError(try self.channel.writeOutbound(ServerMessage.authenticationData(ByteBuffer(bytes: [0x00]), complete: true)))
     }

--- a/Tests/NIOSOCKSTests/ServerStateMachine+Tests.swift
+++ b/Tests/NIOSOCKSTests/ServerStateMachine+Tests.swift
@@ -34,9 +34,6 @@ public class ServerStateMachineTests: XCTestCase {
         XCTAssertNoThrow(try stateMachine.sendAuthenticationMethod(.init(method: .noneRequired)))
         XCTAssertFalse(stateMachine.proxyEstablished)
         
-        // authentication is now finished, as we didn't send any
-        XCTAssertNoThrow(try stateMachine.authenticationComplete())
-        
         // send the client request
         var request = ByteBuffer(bytes: [0x05, 0x01, 0x00, 0x01, 127, 0, 0, 1, 0, 80])
         XCTAssertNoThrow(try stateMachine.receiveBuffer(&request))
@@ -61,7 +58,6 @@ public class ServerStateMachineTests: XCTestCase {
         XCTAssertNoThrow(try stateMachine.connectionEstablished())
         XCTAssertNoThrow(try stateMachine.receiveBuffer(&greeting))
         XCTAssertNoThrow(try stateMachine.sendAuthenticationMethod(.init(method: .noneRequired)))
-        XCTAssertNoThrow(try stateMachine.authenticationComplete())
         
         // write some invalid bytes from the client
         // the state machine should throw


### PR DESCRIPTION
Add a fast path to auto-authenticate when the server selects `noneRequired` as the SOCKS server authentication method.