### PR TITLE
Add SOCKSProxyEstablishedEvent

### DIFF
--- a/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
+++ b/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
@@ -28,6 +28,7 @@ public final class SOCKSClientHandler: ChannelDuplexHandler {
     private let targetAddress: SOCKSAddress
     
     private var state: ClientStateMachine
+    private var removalToken: ChannelHandlerContext.RemovalToken?
     private var inboundBuffer: ByteBuffer?
     
     private var bufferedWrites: MarkedCircularBuffer<(NIOAny, EventLoopPromise<Void>?)> = .init(initialCapacity: 8)
@@ -95,6 +96,11 @@ public final class SOCKSClientHandler: ChannelDuplexHandler {
             context.write(data, promise: promise)
         }
         context.flush() // safe to flush otherwise we wouldn't have the mark
+        
+        while !self.bufferedWrites.isEmpty {
+            let (data, promise) = self.bufferedWrites.removeFirst()
+            context.write(data, promise: promise)
+        }
     }
     
     public func flush(context: ChannelHandlerContext) {
@@ -140,18 +146,13 @@ extension SOCKSClientHandler {
     }
     
     private func handleProxyEstablished(context: ChannelHandlerContext) {
-        // for some reason we have extra bytes
-        // so let's send them down the pipe
-        // (Safe to bang, self.buffered will always exist at this point)
-        if self.inboundBuffer!.readableBytes > 0 {
-            let data = self.wrapInboundOut(self.inboundBuffer!)
-            context.fireChannelRead(data)
-        }
-        
-        // If we have any buffered writes then now
-        // we can send them.
-        self.writeBufferedData(context: context)
         context.fireUserInboundEventTriggered(SOCKSProxyEstablishedEvent())
+        
+        self.emptyInboundAndOutboundBuffer(context: context)
+        
+        if let removalToken = self.removalToken {
+            context.leavePipeline(removalToken: removalToken)
+        }
     }
     
     private func handleActionSendRequest(context: ChannelHandlerContext) throws {
@@ -166,14 +167,33 @@ extension SOCKSClientHandler {
         context.writeAndFlush(self.wrapOutboundOut(buffer), promise: nil)
     }
     
+    private func emptyInboundAndOutboundBuffer(context: ChannelHandlerContext) {
+        if let inboundBuffer = self.inboundBuffer, inboundBuffer.readableBytes > 0 {
+            // after the SOCKS handshake message we already received further bytes.
+            // so let's send them down the pipe
+            self.inboundBuffer = nil
+            context.fireChannelRead(self.wrapInboundOut(inboundBuffer))
+        }
+        
+        // If we have any buffered writes, we must send them before we are removed from the pipeline
+        self.writeBufferedData(context: context)
+    }
 }
 
 extension SOCKSClientHandler: RemovableChannelHandler {
     
     public func removeHandler(context: ChannelHandlerContext, removalToken: ChannelHandlerContext.RemovalToken) {
         guard self.state.proxyEstablished else {
-            preconditionFailure("The SOCKSClientHandler can only be removed once a connection has been established")
+            self.removalToken = removalToken
+            return
         }
+        
+        // We must clear the buffers here before we are removed, since the
+        // handler removal may be triggered as a side effect of the
+        // `SOCKSProxyEstablishedEvent`. In this case we may end up here,
+        // before the buffer empty method in `handleProxyEstablished` is
+        // invoked.
+        self.emptyInboundAndOutboundBuffer(context: context)
         context.leavePipeline(removalToken: removalToken)
     }
     

--- a/Sources/NIOSOCKS/Channel Handlers/SOCKSServerHandshakeHandler.swift
+++ b/Sources/NIOSOCKS/Channel Handlers/SOCKSServerHandshakeHandler.swift
@@ -99,6 +99,9 @@ public final class SOCKSServerHandshakeHandler: ChannelDuplexHandler, RemovableC
     private func handleWriteResponse(
         _ response: SOCKSResponse, context: ChannelHandlerContext) throws -> ByteBuffer {
         try stateMachine.sendServerResponse(response)
+        if case .succeeded = response.reply {
+            context.fireUserInboundEventTriggered(SOCKSProxyEstablishedEvent())
+        }
         var buffer = context.channel.allocator.buffer(capacity: 16)
         buffer.writeServerResponse(response)
         return buffer

--- a/Tests/NIOSOCKSTests/SocksClientHandler+Tests+XCTest.swift
+++ b/Tests/NIOSOCKSTests/SocksClientHandler+Tests+XCTest.swift
@@ -34,6 +34,8 @@ extension SocksClientHandlerTests {
                 ("testProxyConnectionFailed", testProxyConnectionFailed),
                 ("testDelayedConnection", testDelayedConnection),
                 ("testDelayedHandlerAdded", testDelayedHandlerAdded),
+                ("testHandlerRemovalAfterEstablishEvent", testHandlerRemovalAfterEstablishEvent),
+                ("testHandlerRemovalBeforeConnectionIsEstablished", testHandlerRemovalBeforeConnectionIsEstablished),
            ]
    }
 }

--- a/Tests/NIOSOCKSTests/SocksClientHandler+Tests.swift
+++ b/Tests/NIOSOCKSTests/SocksClientHandler+Tests.swift
@@ -264,10 +264,11 @@ class SocksClientHandlerTests: XCTestCase {
             self.channel.pipeline.removeHandler(self.handler).cascade(to: removalPromise)
         }
         
-        try! self.channel.pipeline.addHandler(SOCKSEventHandler(establishedPromise: establishPromise)).wait()
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(SOCKSEventHandler(establishedPromise: establishPromise)).wait())
         
         self.connect()
         
+        // these writes should be buffered to be send out once the connection is established.
         self.channel.write(ByteBuffer(bytes: [1, 2, 3]), promise: nil)
         self.channel.flush()
         self.channel.write(ByteBuffer(bytes: [4, 5, 6]), promise: nil)
@@ -293,6 +294,7 @@ class SocksClientHandlerTests: XCTestCase {
     func testHandlerRemovalBeforeConnectionIsEstablished() {
         self.connect()
         
+        // these writes should be buffered to be send out once the connection is established.
         self.channel.write(ByteBuffer(bytes: [1, 2, 3]), promise: nil)
         self.channel.flush()
         self.channel.write(ByteBuffer(bytes: [4, 5, 6]), promise: nil)


### PR DESCRIPTION
Adds a `SOCKSProxyEstablishedEvent` that is issued once the SOCKS connection is established.

### Motivation:

- We want to know when the SOCKS proxy connection was established.

### Modifications:

- The `SOCKSClientHandler` and `SOCKSServerHandshakeHandler` issue a connect event

### Result:

- We can observe successful proxy connection handshakes
