### PR TITLE
SOCKSClientHandler removes itself on proxy established

### DIFF
--- a/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
+++ b/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
@@ -166,7 +166,7 @@ extension SOCKSClientHandler {
         // If we have any buffered writes then now we can send them.
         self.writeBufferedData(context: context)
         
-        // Remove ourselfes from the channel pipeline and fulfill the establishPromise
+        // Remove ourselves from the channel pipeline and fulfill the establishPromise
         context.channel.pipeline.removeHandler(self).cascade(to: self.connectionEstablishedPromise)
     }
     

--- a/Tests/NIOSOCKSTests/SocksClientHandler+Tests+XCTest.swift
+++ b/Tests/NIOSOCKSTests/SocksClientHandler+Tests+XCTest.swift
@@ -34,6 +34,7 @@ extension SocksClientHandlerTests {
                 ("testProxyConnectionFailed", testProxyConnectionFailed),
                 ("testDelayedConnection", testDelayedConnection),
                 ("testDelayedHandlerAdded", testDelayedHandlerAdded),
+                ("testPromiseIsSucceededOnceConnectionIsEstablished", testPromiseIsSucceededOnceConnectionIsEstablished),
            ]
    }
 }


### PR DESCRIPTION
Alternative to #136. 

### Motivation:

- Once a SOCKS connection has been established we want to remove the `SOCKSClientHandler` from the channel pipeline and potentially do other pipeline modifications.

### Modifications:

- The `SOCKSClientHandler` removes itself from the channel pipeline once the connection was successfully established.
- An `establishHandler: @escaping ((Channel) -> EventLoopFuture<Void>)` is offered to allow for other pipeline modifications.

### Result:

- We can observe successful proxy connection handshakes and the user does not have to remove the `SOCKSClientHandler` themselves
