### PR TITLE
Fix concurrency warning

### DIFF
--- a/Sources/NIOExtrasPerformanceTester/main.swift
+++ b/Sources/NIOExtrasPerformanceTester/main.swift
@@ -13,14 +13,17 @@
 //===----------------------------------------------------------------------===//
 
 // MARK:  Setup
-var warning: String = ""
-assert({
-    print("============================================================")
-    print("= YOU ARE RUNNING NIOExtrasPerformanceTester IN DEBUG MODE =")
-    print("============================================================")
-    warning = " <<< DEBUG MODE >>>"
-    return true
-    }())
+let warning: String = {
+    var warning: String = ""
+    assert({
+        print("============================================================")
+        print("= YOU ARE RUNNING NIOExtrasPerformanceTester IN DEBUG MODE =")
+        print("============================================================")
+        warning = " <<< DEBUG MODE >>>"
+        return true
+        }())
+    return warning
+}()
 
 // MARK:  Tests
 // Test PCAP to file.


### PR DESCRIPTION
Motivation:

A clean build is good.

Modifications:

Make the warning string for debug mode a let constant.

Result:

No warning about concurrency safety.