### PR TITLE
Bump the lowest NIO version to 2.34.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -119,7 +119,7 @@ let package = Package(
         .library(name: "NIOHTTPCompression", targets: ["NIOHTTPCompression"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.34.0"),
     ],
     targets: targets
 )


### PR DESCRIPTION
We introduced `NIOSendable` dependency here, but didn't lift the lower bound on the required NIO version. As it was introduced in 2.34, we need to require that version.