### PR TITLE
Deprecate cumulationBuffer

### DIFF
--- a/Sources/NIOExtras/FixedLengthFrameDecoder.swift
+++ b/Sources/NIOExtras/FixedLengthFrameDecoder.swift
@@ -32,6 +32,7 @@ public final class FixedLengthFrameDecoder: ByteToMessageDecoder {
     public typealias InboundIn = ByteBuffer
     public typealias InboundOut = ByteBuffer
 
+    @available(*, deprecated, message: "No longer used")
     public var cumulationBuffer: ByteBuffer?
 
     private let frameLength: Int

--- a/Sources/NIOExtras/LengthFieldBasedFrameDecoder.swift
+++ b/Sources/NIOExtras/LengthFieldBasedFrameDecoder.swift
@@ -105,7 +105,8 @@ public final class LengthFieldBasedFrameDecoder: ByteToMessageDecoder {
 
     public typealias InboundIn = ByteBuffer
     public typealias InboundOut = ByteBuffer
-    
+
+    @available(*, deprecated, message: "No longer used")
     public var cumulationBuffer: ByteBuffer?
     private var readState: DecoderReadState = .waitingForHeader
     

--- a/Sources/NIOExtras/LineBasedFrameDecoder.swift
+++ b/Sources/NIOExtras/LineBasedFrameDecoder.swift
@@ -33,6 +33,8 @@ import NIOCore
 public class LineBasedFrameDecoder: ByteToMessageDecoder {
     public typealias InboundIn = ByteBuffer
     public typealias InboundOut = ByteBuffer
+    
+    @available(*, deprecated, message: "No longer used")
     public var cumulationBuffer: ByteBuffer?
     // keep track of the last scan offset from the buffer's reader index (if we didn't find the delimiter)
     private var lastScanOffset = 0


### PR DESCRIPTION
Motivation:

It is no longer used.

Modifications:

Deprecate the 3 cumulationBuffers

Result:

Less confusion and accidental usage.