### PR TITLE
Backport #177 to 1.10 release

### DIFF
--- a/Sources/NIOHTTPCompression/HTTPDecompression.swift
+++ b/Sources/NIOHTTPCompression/HTTPDecompression.swift
@@ -52,6 +52,29 @@ public enum NIOHTTPDecompression {
         case initializationError(Int)
     }
 
+    public struct ExtraDecompressionError: Error, Hashable, CustomStringConvertible {
+        private var backing: Backing
+
+        private enum Backing {
+            case invalidTrailingData
+            case truncatedData
+        }
+
+        private init(_ backing: Backing) {
+            self.backing = backing
+        }
+
+        /// Decompression completed but there was invalid trailing data behind the compressed data.
+        public static let invalidTrailingData = Self(.invalidTrailingData)
+
+        /// The decompressed data was incorrectly truncated.
+        public static let truncatedData = Self(.truncatedData)
+
+        public var description: String {
+            return String(describing: self.backing)
+        }
+    }
+
     enum CompressionAlgorithm: String {
         case gzip
         case deflate
@@ -86,12 +109,15 @@ public enum NIOHTTPDecompression {
             self.limit = limit
         }
 
-        mutating func decompress(part: inout ByteBuffer, buffer: inout ByteBuffer, compressedLength: Int) throws {
-            self.inflated += try self.stream.inflatePart(input: &part, output: &buffer)
+        mutating func decompress(part: inout ByteBuffer, buffer: inout ByteBuffer, compressedLength: Int) throws -> InflateResult {
+            let result = try self.stream.inflatePart(input: &part, output: &buffer)
+            self.inflated += result.written
 
             if self.limit.exceeded(compressed: compressedLength, decompressed: self.inflated) {
                 throw NIOHTTPDecompression.DecompressionError.limit
             }
+
+            return result
         }
 
         mutating func initializeDecoder(encoding: NIOHTTPDecompression.CompressionAlgorithm) throws {
@@ -112,9 +138,10 @@ public enum NIOHTTPDecompression {
 }
 
 extension z_stream {
-    mutating func inflatePart(input: inout ByteBuffer, output: inout ByteBuffer) throws -> Int {
+    mutating func inflatePart(input: inout ByteBuffer, output: inout ByteBuffer) throws -> InflateResult {
         let minimumCapacity = input.readableBytes * 2
-        var written = 0
+        var inflateResult = InflateResult(written: 0, complete: false)
+
         try input.readWithUnsafeMutableReadableBytes { pointer in
             self.avail_in = UInt32(pointer.count)
             self.next_in = CNIOExtrasZlib_voidPtr_to_BytefPtr(pointer.baseAddress!)
@@ -126,24 +153,34 @@ extension z_stream {
                 self.next_out = nil
             }
 
-            written += try self.inflatePart(to: &output, minimumCapacity: minimumCapacity)
+            inflateResult = try self.inflatePart(to: &output, minimumCapacity: minimumCapacity)
 
             return pointer.count - Int(self.avail_in)
         }
-        return written
+        return inflateResult
     }
 
-    private mutating func inflatePart(to buffer: inout ByteBuffer, minimumCapacity: Int) throws -> Int {
-        return try buffer.writeWithUnsafeMutableBytes(minimumWritableBytes: minimumCapacity) { pointer in
+    private mutating func inflatePart(to buffer: inout ByteBuffer, minimumCapacity: Int) throws -> InflateResult {
+        var rc = Z_OK
+
+        let written = try buffer.writeWithUnsafeMutableBytes(minimumWritableBytes: minimumCapacity) { pointer in
             self.avail_out = UInt32(pointer.count)
             self.next_out = CNIOExtrasZlib_voidPtr_to_BytefPtr(pointer.baseAddress!)
 
-            let rc = inflate(&self, Z_NO_FLUSH)
+            rc = inflate(&self, Z_NO_FLUSH)
             guard rc == Z_OK || rc == Z_STREAM_END else {
                 throw NIOHTTPDecompression.DecompressionError.inflationError(Int(rc))
             }
 
             return pointer.count - Int(self.avail_out)
         }
+
+        return InflateResult(written: written, complete: rc == Z_STREAM_END)
     }
+}
+
+struct InflateResult {
+    var written: Int
+
+    var complete: Bool
 }

--- a/Sources/NIOHTTPCompression/HTTPDecompression.swift
+++ b/Sources/NIOHTTPCompression/HTTPDecompression.swift
@@ -52,7 +52,8 @@ public enum NIOHTTPDecompression {
         case initializationError(Int)
     }
 
-    public struct ExtraDecompressionError: Error, Hashable, CustomStringConvertible {
+    // Would have been public, but this is a backport and cannot add new API.
+    internal struct ExtraDecompressionError: Error, Hashable, CustomStringConvertible {
         private var backing: Backing
 
         private enum Backing {
@@ -65,12 +66,12 @@ public enum NIOHTTPDecompression {
         }
 
         /// Decompression completed but there was invalid trailing data behind the compressed data.
-        public static let invalidTrailingData = Self(.invalidTrailingData)
+        static let invalidTrailingData = Self(.invalidTrailingData)
 
         /// The decompressed data was incorrectly truncated.
-        public static let truncatedData = Self(.truncatedData)
+        static let truncatedData = Self(.truncatedData)
 
-        public var description: String {
+        var description: String {
             return String(describing: self.backing)
         }
     }

--- a/Sources/NIOHTTPCompression/HTTPRequestDecompressor.swift
+++ b/Sources/NIOHTTPCompression/HTTPRequestDecompressor.swift
@@ -29,10 +29,12 @@ public final class NIOHTTPRequestDecompressor: ChannelDuplexHandler, RemovableCh
 
     private var decompressor: NIOHTTPDecompression.Decompressor
     private var compression: Compression?
+    private var decompressionComplete: Bool
 
     public init(limit: NIOHTTPDecompression.DecompressionLimit) {
         self.decompressor = NIOHTTPDecompression.Decompressor(limit: limit)
         self.compression = nil
+        self.decompressionComplete = false
     }
 
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -61,10 +63,13 @@ public final class NIOHTTPRequestDecompressor: ChannelDuplexHandler, RemovableCh
                 return
             }
 
-            while part.readableBytes > 0 {
+            while part.readableBytes > 0 && !self.decompressionComplete {
                 do {
                     var buffer = context.channel.allocator.buffer(capacity: 16384)
-                    try self.decompressor.decompress(part: &part, buffer: &buffer, compressedLength: compression.contentLength)
+                    let result = try self.decompressor.decompress(part: &part, buffer: &buffer, compressedLength: compression.contentLength)
+                    if result.complete {
+                        self.decompressionComplete = true
+                    }
 
                     context.fireChannelRead(self.wrapInboundOut(.body(buffer)))
                 } catch let error {
@@ -72,10 +77,21 @@ public final class NIOHTTPRequestDecompressor: ChannelDuplexHandler, RemovableCh
                     return
                 }
             }
+
+            if part.readableBytes > 0 {
+                context.fireErrorCaught(NIOHTTPDecompression.ExtraDecompressionError.invalidTrailingData)
+            }
         case .end:
             if self.compression != nil {
+                let wasDecompressionComplete = self.decompressionComplete
+
                 self.decompressor.deinitializeDecoder()
                 self.compression = nil
+                self.decompressionComplete = false
+
+                if !wasDecompressionComplete {
+                    context.fireErrorCaught(NIOHTTPDecompression.ExtraDecompressionError.truncatedData)
+                }
             }
 
             context.fireChannelRead(data)

--- a/Tests/NIOHTTPCompressionTests/HTTPRequestDecompressorTest+XCTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPRequestDecompressorTest+XCTest.swift
@@ -30,6 +30,8 @@ extension HTTPRequestDecompressorTest {
                 ("testDecompressionLimitRatio", testDecompressionLimitRatio),
                 ("testDecompressionLimitSize", testDecompressionLimitSize),
                 ("testDecompression", testDecompression),
+                ("testDecompressionTrailingData", testDecompressionTrailingData),
+                ("testDecompressionTruncatedInput", testDecompressionTruncatedInput),
            ]
    }
 }

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest+XCTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest+XCTest.swift
@@ -37,6 +37,8 @@ extension HTTPResponseDecompressorTest {
                 ("testDecompressionLimitRatioWithoutContentLenghtHeaderFails", testDecompressionLimitRatioWithoutContentLenghtHeaderFails),
                 ("testDecompression", testDecompression),
                 ("testDecompressionWithoutContentLength", testDecompressionWithoutContentLength),
+                ("testDecompressionTrailingData", testDecompressionTrailingData),
+                ("testDecompressionTruncatedInput", testDecompressionTruncatedInput),
            ]
    }
 }


### PR DESCRIPTION
This is a backport of #177 to the 1.10 release series, supporting Swift 5.2. It contains an extra patch to ensure that we do not add new API, making it possible for this to be 1.10.3.