### PR TITLE
Replace `NIOSendable` with `Sendable`

### DIFF
--- a/Sources/NIOExtras/NIOLengthFieldBitLength.swift
+++ b/Sources/NIOExtras/NIOLengthFieldBitLength.swift
@@ -15,7 +15,7 @@
 import NIOCore
 
 /// A struct to describe the length of a piece of data in bits
-public struct NIOLengthFieldBitLength: NIOSendable {
+public struct NIOLengthFieldBitLength: Sendable {
     internal enum Backing {
         case bits8
         case bits16

--- a/Sources/NIOExtras/QuiescingHelper.swift
+++ b/Sources/NIOExtras/QuiescingHelper.swift
@@ -259,6 +259,6 @@ public final class ServerQuiescingHelper {
     }
 }
 
-extension ServerQuiescingHelper: NIOSendable {
+extension ServerQuiescingHelper: Sendable {
 
 }

--- a/Sources/NIOHTTPCompression/HTTPCompression.swift
+++ b/Sources/NIOHTTPCompression/HTTPCompression.swift
@@ -19,7 +19,7 @@ import NIOCore
 public enum NIOCompression {
 
     /// Which algorithm should be used for compression.
-    public struct Algorithm: CustomStringConvertible, Equatable, NIOSendable {
+    public struct Algorithm: CustomStringConvertible, Equatable, Sendable {
         fileprivate enum AlgorithmEnum: String {
             case gzip
             case deflate

--- a/Sources/NIOHTTPCompression/HTTPDecompression.swift
+++ b/Sources/NIOHTTPCompression/HTTPDecompression.swift
@@ -18,7 +18,7 @@ import NIOCore
 /// Namespace for decompression code.
 public enum NIOHTTPDecompression {
     /// Specifies how to limit decompression inflation.
-    public struct DecompressionLimit: NIOSendable {
+    public struct DecompressionLimit: Sendable {
         private enum Limit {
             case none
             case size(Int)

--- a/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
+++ b/Sources/NIOSOCKS/Channel Handlers/SOCKSClientHandler.swift
@@ -212,7 +212,7 @@ extension SOCKSClientHandler: RemovableChannelHandler {
 /// A `Channel` user event that is sent when a SOCKS connection has been established
 ///
 /// After this event has been received it is save to remove the `SOCKSClientHandler` from the channel pipeline.
-public struct SOCKSProxyEstablishedEvent: NIOSendable {
+public struct SOCKSProxyEstablishedEvent: Sendable {
     public init() {
     }
 }

--- a/Sources/NIOSOCKS/Messages/AuthenticationMethod.swift
+++ b/Sources/NIOSOCKS/Messages/AuthenticationMethod.swift
@@ -15,7 +15,7 @@
 import NIOCore
 
 /// The SOCKS authentication method to use, defined in RFC 1928.
-public struct AuthenticationMethod: Hashable, NIOSendable {
+public struct AuthenticationMethod: Hashable, Sendable {
     
     /// No authentication required
     public static let noneRequired = AuthenticationMethod(value: 0x00)

--- a/Sources/NIOSOCKS/Messages/ClientGreeting.swift
+++ b/Sources/NIOSOCKS/Messages/ClientGreeting.swift
@@ -17,7 +17,7 @@ import NIOCore
 /// Clients begin the SOCKS handshake process
 /// by providing an array of suggested authentication
 /// methods.
-public struct ClientGreeting: Hashable, NIOSendable {
+public struct ClientGreeting: Hashable, Sendable {
     
     /// The protocol version.
     public let version: UInt8 = 5

--- a/Sources/NIOSOCKS/Messages/Messages.swift
+++ b/Sources/NIOSOCKS/Messages/Messages.swift
@@ -15,7 +15,7 @@
 import NIOCore
 
 /// Sent by the client and received by the server.
-public enum ClientMessage: Hashable, NIOSendable {
+public enum ClientMessage: Hashable, Sendable {
     
     /// Contains the proposed authentication methods.
     case greeting(ClientGreeting)
@@ -28,7 +28,7 @@ public enum ClientMessage: Hashable, NIOSendable {
 }
 
 /// Sent by the server and received by the client.
-public enum ServerMessage: Hashable, NIOSendable {
+public enum ServerMessage: Hashable, Sendable {
     
     /// Used by the server to instruct the client of the authentication method to use.
     case selectedAuthenticationMethod(SelectedAuthenticationMethod)

--- a/Sources/NIOSOCKS/Messages/SOCKSRequest.swift
+++ b/Sources/NIOSOCKS/Messages/SOCKSRequest.swift
@@ -24,7 +24,7 @@ import NIOCore
 
 /// Instructs the SOCKS proxy server of the target host,
 /// and how to connect.
-public struct SOCKSRequest: Hashable, NIOSendable {
+public struct SOCKSRequest: Hashable, Sendable {
     
     /// The SOCKS protocol version - we currently only support v5.
     public let version: UInt8 = 5
@@ -75,7 +75,7 @@ extension ByteBuffer {
 
 /// What type of connection the SOCKS server should establish with
 /// the target host.
-public struct SOCKSCommand: Hashable, NIOSendable {
+public struct SOCKSCommand: Hashable, Sendable {
     
     /// Typically the primary connection type, suitable for HTTP.
     public static let connect = SOCKSCommand(value: 0x01)
@@ -99,7 +99,7 @@ public struct SOCKSCommand: Hashable, NIOSendable {
 // MARK: - SOCKSAddress
 
 /// The address used to connect to the target host.
-public enum SOCKSAddress: Hashable, NIOSendable {
+public enum SOCKSAddress: Hashable, Sendable {
     /// Socket Adress
     case address(SocketAddress)
     /// Host and port

--- a/Sources/NIOSOCKS/Messages/SOCKSResponse.swift
+++ b/Sources/NIOSOCKS/Messages/SOCKSResponse.swift
@@ -18,7 +18,7 @@ import NIOCore
 
 /// The SOCKS Server's response to the client's request
 /// indicating if the request succeeded or failed.
-public struct SOCKSResponse: Hashable, NIOSendable {
+public struct SOCKSResponse: Hashable, Sendable {
     
     /// The SOCKS protocol version - we currently only support v5.
     public let version: UInt8 = 5
@@ -69,7 +69,7 @@ extension ByteBuffer {
 
 /// Used to indicate if the SOCKS client's connection request succeeded
 /// or failed.
-public struct SOCKSServerReply: Hashable, NIOSendable {
+public struct SOCKSServerReply: Hashable, Sendable {
     
     /// The connection succeeded and data can now be transmitted.
     public static let succeeded = SOCKSServerReply(value: 0x00)

--- a/Sources/NIOSOCKS/Messages/SelectedAuthenticationMethod.swift
+++ b/Sources/NIOSOCKS/Messages/SelectedAuthenticationMethod.swift
@@ -17,7 +17,7 @@ import NIOCore
 /// Used by the SOCKS server to inform the client which
 /// authentication method it would like to use out of those
 /// offered.
-public struct SelectedAuthenticationMethod: Hashable, NIOSendable {
+public struct SelectedAuthenticationMethod: Hashable, Sendable {
     
     /// The SOCKS protocol version - we currently only support v5.
     public let version: UInt8 = 5


### PR DESCRIPTION
We now require Swift 5.5.2 which includes `Sendable` so we no longer require the `NIOSendable` workaround.
`NIOSendable` is just a `typealias` of `Sendable` so this is a non source breaking change.
This allows `swift-nio` to eventually deprecate `NIOSendable`.