### PR TITLE
Remove `#if compiler(>=5.5)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All code will go through code review like in the other repositories related to t
 `swift-nio-extras` part of the SwiftNIO 2 family of repositories and depends on the following:
 
 - [`swift-nio`](https://github.com/apple/swift-nio), version 2.30.0 or better.
-- Swift 5.5.
+- Swift 5.5.2.
 - `zlib` and its development headers installed on the system. But don't worry, you'll find `zlib` on pretty much any UNIX system that can compile any sort of code.
 
 To depend on `swift-nio-extras`, put the following in the `dependencies` of your `Package.swift`:
@@ -25,14 +25,14 @@ To depend on `swift-nio-extras`, put the following in the `dependencies` of your
 
 ### Support for older Swift versions
 
-The most recent versions of SwiftNIO Extras support Swift 5.5 and newer. The minimum Swift version supported by SwiftNIO Extras releases are detailed below:
+The most recent versions of SwiftNIO Extras support Swift 5.5.2 and newer. The minimum Swift version supported by SwiftNIO Extras releases are detailed below:
 
 SwiftNIO Extras     | Minimum Swift Version
 --------------------|----------------------
 `1.0.0 ..< 1.10.0`  | 5.0
 `1.10.0 ..< 1.11.0` | 5.2
 `1.11.0 ..< 1.14.0` | 5.4
-`1.14.0 ...`        | 5.5
+`1.14.0 ...`        | 5.5.2
 
 On the [`nio-extras-0.1`](https://github.com/apple/swift-nio-extras/tree/nio-extras-0.1) branch, you can find the `swift-nio-extras` version for the SwiftNIO 1 family. It requires Swift 4.1 or better.
 

--- a/Sources/NIOExtras/QuiescingHelper.swift
+++ b/Sources/NIOExtras/QuiescingHelper.swift
@@ -144,11 +144,8 @@ private final class ChannelCollector {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
-extension ChannelCollector: @unchecked Sendable {
 
-}
-#endif
+extension ChannelCollector: @unchecked Sendable {}
 
 /// A `ChannelHandler` that adds all channels that it receives through the `ChannelPipeline` to a `ChannelCollector`.
 ///

--- a/Sources/NIOExtras/WritePCAPHandler.swift
+++ b/Sources/NIOExtras/WritePCAPHandler.swift
@@ -722,8 +722,4 @@ extension NIOWritePCAPHandler {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
-extension NIOWritePCAPHandler.SynchronizedFileSink: @unchecked Sendable {
-
-}
-#endif
+extension NIOWritePCAPHandler.SynchronizedFileSink: @unchecked Sendable {}


### PR DESCRIPTION
### Motivation
We only support Swift 5.5.2+. 

### Modification
Remove all `#if swift(>=5.5)` conditional compilation blocks.

### Result
less branching
