### PR TITLE
Use #fileID/#filePath instead of #file

### DIFF
--- a/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
+++ b/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
@@ -62,7 +62,7 @@ class WritePCAPHandlerTest: XCTestCase {
     func assertEqual(expectedAddress: SocketAddress?,
                      actualIPv4Address: in_addr,
                      actualPort: UInt16,
-                     file: StaticString = #file,
+                     file: StaticString = #filePath,
                      line: UInt = #line) {
         guard let port = expectedAddress?.port else {
             XCTFail("expected address nil or has no port", file: (file), line: line)
@@ -83,7 +83,7 @@ class WritePCAPHandlerTest: XCTestCase {
     func assertEqual(expectedAddress: SocketAddress?,
                      actualIPv6Address: in6_addr,
                      actualPort: UInt16,
-                     file: StaticString = #file,
+                     file: StaticString = #filePath,
                      line: UInt = #line) {
         guard let port = expectedAddress?.port else {
             XCTFail("expected address nil or has no port", file: (file), line: line)

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
@@ -29,7 +29,7 @@ private class PromiseOrderer {
         self.eventLoop = eventLoop
     }
 
-    func makePromise(file: StaticString = #file, line: UInt = #line) -> EventLoopPromise<Void> {
+    func makePromise(file: StaticString = #fileID, line: UInt = #line) -> EventLoopPromise<Void> {
         let promise = eventLoop.makePromise(of: Void.self, file: (file), line: line)
         appendPromise(promise)
         return promise


### PR DESCRIPTION
Use #fileID/#filePath instead of #file

Motivation:

#fileID introduced in Swift 5.3, so no longer need to use #file anywhere                                  

Modifications:

Changed #file to #filePath or #fileID depending on situation