### PR TITLE
ServerQuiescingHelper no longer leaking promises

### DIFF
--- a/Sources/NIOExtras/QuiescingHelper.swift
+++ b/Sources/NIOExtras/QuiescingHelper.swift
@@ -216,6 +216,7 @@ private final class CollectAcceptedChannelsHandler: ChannelInboundHandler {
 ///     try fullyShutdownPromise.futureResult.wait()
 ///
 public final class ServerQuiescingHelper {
+    public struct UnusedQuiescingHelperError: Error {}
     private let channelCollectorPromise: EventLoopPromise<ChannelCollector>
 
     /// Initialize with a given `EventLoopGroup`.
@@ -226,6 +227,11 @@ public final class ServerQuiescingHelper {
         self.channelCollectorPromise = group.next().makePromise()
     }
 
+    /// Deinitilaize the `channelCollectorPromise` with failure when promise never succeeded
+    deinit {
+        self.channelCollectorPromise.fail(UnusedQuiescingHelperError())
+    }
+    
     /// Create the `ChannelHandler` for the server `channel` to collect all accepted child `Channel`s.
     ///
     /// - parameters:

--- a/Sources/NIOExtras/QuiescingHelper.swift
+++ b/Sources/NIOExtras/QuiescingHelper.swift
@@ -216,6 +216,7 @@ private final class CollectAcceptedChannelsHandler: ChannelInboundHandler {
 ///     try fullyShutdownPromise.futureResult.wait()
 ///
 public final class ServerQuiescingHelper {
+    /// The `ServerQuiescingHelper` was never used to create a channel handler.
     public struct UnusedQuiescingHelperError: Error {}
     private let channelCollectorPromise: EventLoopPromise<ChannelCollector>
 
@@ -227,7 +228,6 @@ public final class ServerQuiescingHelper {
         self.channelCollectorPromise = group.next().makePromise()
     }
 
-    /// Deinitilaize the `channelCollectorPromise` with failure when promise never succeeded
     deinit {
         self.channelCollectorPromise.fail(UnusedQuiescingHelperError())
     }

--- a/Tests/NIOExtrasTests/QuiescingHelperTest+XCTest.swift
+++ b/Tests/NIOExtrasTests/QuiescingHelperTest+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2018-2022 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2018-2023 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/NIOExtrasTests/QuiescingHelperTest+XCTest.swift
+++ b/Tests/NIOExtrasTests/QuiescingHelperTest+XCTest.swift
@@ -30,6 +30,7 @@ extension QuiescingHelperTest {
                 ("testShutdownIsImmediateWhenNoChannelsCollected", testShutdownIsImmediateWhenNoChannelsCollected),
                 ("testQuiesceUserEventReceivedOnShutdown", testQuiesceUserEventReceivedOnShutdown),
                 ("testQuiescingDoesNotSwallowCloseErrorsFromAcceptHandler", testQuiescingDoesNotSwallowCloseErrorsFromAcceptHandler),
+                ("testShutdownIsImmediateWhenPromiseDoesNotSucceed", testShutdownIsImmediateWhenPromiseDoesNotSucceed),
            ]
    }
 }

--- a/Tests/NIOExtrasTests/QuiescingHelperTest.swift
+++ b/Tests/NIOExtrasTests/QuiescingHelperTest.swift
@@ -136,4 +136,19 @@ public class QuiescingHelperTest: XCTestCase {
             XCTAssert(error is DummyError)
         }
     }
+
+    ///verifying that the promise fails when goes out of scope for shutdown
+    func testShutdownIsImmediateWhenPromiseDoesNotSucceed() throws {
+        let el = EmbeddedEventLoop()
+
+        let p: EventLoopPromise<Void> = el.makePromise()
+
+        do {
+            let quiesce = ServerQuiescingHelper(group: el)
+            quiesce.initiateShutdown(promise: p)
+        }
+        XCTAssertThrowsError(try p.futureResult.wait()) { error in
+            XCTAssertTrue(error is ServerQuiescingHelper.UnusedQuiescingHelperError)
+        }
+    }
 }


### PR DESCRIPTION
Motivation:
ServerQuiescingHelper leaked promises when promise left scope and not succeeded

Modifications:
Failing promise within a deinit
