### PR TITLE
Refactor `QuiescingHelper` to exhaustively iterate state

### DIFF
--- a/Tests/NIOExtrasTests/QuiescingHelperTest+XCTest.swift
+++ b/Tests/NIOExtrasTests/QuiescingHelperTest+XCTest.swift
@@ -31,6 +31,11 @@ extension QuiescingHelperTest {
                 ("testQuiesceUserEventReceivedOnShutdown", testQuiesceUserEventReceivedOnShutdown),
                 ("testQuiescingDoesNotSwallowCloseErrorsFromAcceptHandler", testQuiescingDoesNotSwallowCloseErrorsFromAcceptHandler),
                 ("testShutdownIsImmediateWhenPromiseDoesNotSucceed", testShutdownIsImmediateWhenPromiseDoesNotSucceed),
+                ("testShutdown_whenAlreadyShutdown", testShutdown_whenAlreadyShutdown),
+                ("testShutdown_whenNoOpenChild", testShutdown_whenNoOpenChild),
+                ("testChannelClose_whenRunning", testChannelClose_whenRunning),
+                ("testChannelAdded_whenShuttingDown", testChannelAdded_whenShuttingDown),
+                ("testChannelAdded_whenShutdown", testChannelAdded_whenShutdown),
            ]
    }
 }


### PR DESCRIPTION
# Motivation
Currently the `QuiescingHelper` is crashing on a precondition if you call shutdown when it already was shutdown. However, that can totally happen and we should support it.

# Modification
Refactor the `QuiescingHelper` to exhaustively switch over its state in every method. Furthermore, I added a few more test cases to test realistic scenarios.

# Result
We are now reliable checking our state and making sure to allow most transitions.