### PR TITLE
Enforce Sendability

### DIFF
--- a/Sources/NIOExtrasPerformanceTester/HTTP1RollingPCAPPerformanceTests.swift
+++ b/Sources/NIOExtrasPerformanceTester/HTTP1RollingPCAPPerformanceTests.swift
@@ -17,17 +17,21 @@ import NIOExtras
 
 class HTTP1ThreadedRollingPCapPerformanceTest: HTTP1ThreadedPerformanceTest {
     init() {
-        func addRollingPCap(channel: Channel) -> EventLoopFuture<Void> {
-            let pcapRingBuffer = NIOPCAPRingBuffer(maximumFragments: 25,
-                                                   maximumBytes: 1_000_000)
-            let pcapHandler = NIOWritePCAPHandler(mode: .client,
-                                                  fileSink: pcapRingBuffer.addFragment)
+        let addRollingPCap: @Sendable (Channel) -> EventLoopFuture<Void> = { channel in
+            let pcapRingBuffer = NIOPCAPRingBuffer(
+                maximumFragments: 25,
+                maximumBytes: 1_000_000
+            )
+            let pcapHandler = NIOWritePCAPHandler(
+                mode: .client,
+                fileSink: pcapRingBuffer.addFragment
+            )
             return channel.pipeline.addHandler(pcapHandler, position: .first)
         }
 
         super.init(numberOfRepeats: 50,
                    numberOfClients: System.coreCount,
                    requestsPerClient: 500,
-                   extraInitialiser: { channel in return addRollingPCap(channel: channel) })
+                   extraInitialiser: { channel in addRollingPCap(channel) })
     }
 }

--- a/Sources/NIONFS3/NFSFileSystem.swift
+++ b/Sources/NIONFS3/NFSFileSystem.swift
@@ -14,7 +14,8 @@
 
 import NIOCore
 
-public protocol NFS3FileSystemNoAuth {
+@preconcurrency
+public protocol NFS3FileSystemNoAuth: Sendable {
     func mount(_ call: MountCallMount, promise: EventLoopPromise<MountReplyMount>)
     func unmount(_ call: MountCallUnmount, promise: EventLoopPromise<MountReplyUnmount>)
     func getattr(_ call: NFS3CallGetAttr, promise: EventLoopPromise<NFS3ReplyGetAttr>)

--- a/Sources/NIONFS3/NFSFileSystemInvoker.swift
+++ b/Sources/NIONFS3/NFSFileSystemInvoker.swift
@@ -39,122 +39,135 @@ internal struct NFS3FileSystemInvoker<FS: NFS3FileSystemNoAuth, Sink: NFS3FileSy
         case .mountNull:
             self.sink.sendSuccessfulReply(.mountNull, call: callMessage)
         case .mount(let call):
+            let boundedSink = NIOLoopBound(self.sink, eventLoop: self.eventLoop)
             self.fs.mount(call, eventLoop: self.eventLoop).whenComplete { result in
                 switch result {
                 case .success(let reply):
-                    self.sink.sendSuccessfulReply(.mount(reply), call: callMessage)
+                    boundedSink.value.sendSuccessfulReply(.mount(reply), call: callMessage)
                 case .failure(let error):
-                    self.sink.sendError(error, call: callMessage)
+                    boundedSink.value.sendError(error, call: callMessage)
                 }
             }
         case .unmount(let call):
+            let boundedSink = NIOLoopBound(self.sink, eventLoop: self.eventLoop)
             self.fs.unmount(call, eventLoop: self.eventLoop).whenComplete { result in
                 switch result {
                 case .success(let reply):
-                    self.sink.sendSuccessfulReply(.unmount(reply), call: callMessage)
+                    boundedSink.value.sendSuccessfulReply(.unmount(reply), call: callMessage)
                 case .failure(let error):
-                    self.sink.sendError(error, call: callMessage)
+                    boundedSink.value.sendError(error, call: callMessage)
                 }
             }
         case .null:
             self.sink.sendSuccessfulReply(.null, call: callMessage)
         case .getattr(let call):
+            let boundedSink = NIOLoopBound(self.sink, eventLoop: self.eventLoop)
             self.fs.getattr(call, eventLoop: self.eventLoop).whenComplete { result in
                 switch result {
                 case .success(let reply):
-                    self.sink.sendSuccessfulReply(.getattr(reply), call: callMessage)
+                    boundedSink.value.sendSuccessfulReply(.getattr(reply), call: callMessage)
                 case .failure(let error):
-                    self.sink.sendError(error, call: callMessage)
+                    boundedSink.value.sendError(error, call: callMessage)
                 }
             }
         case .fsinfo(let call):
+            let boundedSink = NIOLoopBound(self.sink, eventLoop: self.eventLoop)
             self.fs.fsinfo(call, eventLoop: self.eventLoop).whenComplete { result in
                 switch result {
                 case .success(let reply):
-                    self.sink.sendSuccessfulReply(.fsinfo(reply), call: callMessage)
+                    boundedSink.value.sendSuccessfulReply(.fsinfo(reply), call: callMessage)
                 case .failure(let error):
-                    self.sink.sendError(error, call: callMessage)
+                    boundedSink.value.sendError(error, call: callMessage)
                 }
             }
         case .pathconf(let call):
+            let boundedSink = NIOLoopBound(self.sink, eventLoop: self.eventLoop)
             self.fs.pathconf(call, eventLoop: self.eventLoop).whenComplete { result in
                 switch result {
                 case .success(let reply):
-                    self.sink.sendSuccessfulReply(.pathconf(reply), call: callMessage)
+                    boundedSink.value.sendSuccessfulReply(.pathconf(reply), call: callMessage)
                 case .failure(let error):
-                    self.sink.sendError(error, call: callMessage)
+                    boundedSink.value.sendError(error, call: callMessage)
                 }
             }
         case .fsstat(let call):
+            let boundedSink = NIOLoopBound(self.sink, eventLoop: self.eventLoop)
             self.fs.fsstat(call, eventLoop: self.eventLoop).whenComplete { result in
                 switch result {
                 case .success(let reply):
-                    self.sink.sendSuccessfulReply(.fsstat(reply), call: callMessage)
+                    boundedSink.value.sendSuccessfulReply(.fsstat(reply), call: callMessage)
                 case .failure(let error):
-                    self.sink.sendError(error, call: callMessage)
+                    boundedSink.value.sendError(error, call: callMessage)
                 }
             }
         case .access(let call):
+            let boundedSink = NIOLoopBound(self.sink, eventLoop: self.eventLoop)
             self.fs.access(call, eventLoop: self.eventLoop).whenComplete { result in
                 switch result {
                 case .success(let reply):
-                    self.sink.sendSuccessfulReply(.access(reply), call: callMessage)
+                    boundedSink.value.sendSuccessfulReply(.access(reply), call: callMessage)
                 case .failure(let error):
-                    self.sink.sendError(error, call: callMessage)
+                    boundedSink.value.sendError(error, call: callMessage)
                 }
             }
         case .lookup(let call):
+            let boundedSink = NIOLoopBound(self.sink, eventLoop: self.eventLoop)
             self.fs.lookup(call, eventLoop: self.eventLoop).whenComplete { result in
                 switch result {
                 case .success(let reply):
-                    self.sink.sendSuccessfulReply(.lookup(reply), call: callMessage)
+                    boundedSink.value.sendSuccessfulReply(.lookup(reply), call: callMessage)
                 case .failure(let error):
-                    self.sink.sendError(error, call: callMessage)
+                    boundedSink.value.sendError(error, call: callMessage)
                 }
             }
         case .readdirplus(let call):
+            let boundedSink = NIOLoopBound(self.sink, eventLoop: self.eventLoop)
             self.fs.readdirplus(call, eventLoop: self.eventLoop).whenComplete { result in
                 switch result {
                 case .success(let reply):
-                    self.sink.sendSuccessfulReply(.readdirplus(reply), call: callMessage)
+                    boundedSink.value.sendSuccessfulReply(.readdirplus(reply), call: callMessage)
                 case .failure(let error):
-                    self.sink.sendError(error, call: callMessage)
+                    boundedSink.value.sendError(error, call: callMessage)
                 }
             }
         case .read(let call):
+            let boundedSink = NIOLoopBound(self.sink, eventLoop: self.eventLoop)
             self.fs.read(call, eventLoop: self.eventLoop).whenComplete { result in
                 switch result {
                 case .success(let reply):
-                    self.sink.sendSuccessfulReply(.read(reply), call: callMessage)
+                    boundedSink.value.sendSuccessfulReply(.read(reply), call: callMessage)
                 case .failure(let error):
-                    self.sink.sendError(error, call: callMessage)
+                    boundedSink.value.sendError(error, call: callMessage)
                 }
             }
         case .readdir(let call):
+            let boundedSink = NIOLoopBound(self.sink, eventLoop: self.eventLoop)
             self.fs.readdir(call, eventLoop: self.eventLoop).whenComplete { result in
                 switch result {
                 case .success(let reply):
-                    self.sink.sendSuccessfulReply(.readdir(reply), call: callMessage)
+                    boundedSink.value.sendSuccessfulReply(.readdir(reply), call: callMessage)
                 case .failure(let error):
-                    self.sink.sendError(error, call: callMessage)
+                    boundedSink.value.sendError(error, call: callMessage)
                 }
             }
         case .readlink(let call):
+            let boundedSink = NIOLoopBound(self.sink, eventLoop: self.eventLoop)
             self.fs.readlink(call, eventLoop: self.eventLoop).whenComplete { result in
                 switch result {
                 case .success(let reply):
-                    self.sink.sendSuccessfulReply(.readlink(reply), call: callMessage)
+                    boundedSink.value.sendSuccessfulReply(.readlink(reply), call: callMessage)
                 case .failure(let error):
-                    self.sink.sendError(error, call: callMessage)
+                    boundedSink.value.sendError(error, call: callMessage)
                 }
             }
         case .setattr(let call):
+            let boundedSink = NIOLoopBound(self.sink, eventLoop: self.eventLoop)
             self.fs.setattr(call, eventLoop: self.eventLoop).whenComplete { result in
                 switch result {
                 case .success(let reply):
-                    self.sink.sendSuccessfulReply(.setattr(reply), call: callMessage)
+                    boundedSink.value.sendSuccessfulReply(.setattr(reply), call: callMessage)
                 case .failure(let error):
-                    self.sink.sendError(error, call: callMessage)
+                    boundedSink.value.sendError(error, call: callMessage)
                 }
             }
         case ._PLEASE_DO_NOT_EXHAUSTIVELY_MATCH_THIS_ENUM_NEW_CASES_MIGHT_BE_ADDED_IN_THE_FUTURE:

--- a/Sources/NIOWritePCAPDemo/main.swift
+++ b/Sources/NIOWritePCAPDemo/main.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import NIOCore
 import NIOPosix
 import NIOExtras
@@ -49,8 +50,8 @@ class SendSimpleRequestHandler: ChannelInboundHandler {
     }
 }
 
-guard let outputFile = CommandLine.arguments.dropFirst().first else {
-    print("Usage: \(CommandLine.arguments[0]) OUTPUT.pcap")
+guard let outputFile = ProcessInfo.processInfo.arguments.dropFirst().first else {
+    print("Usage: \(ProcessInfo.processInfo.arguments[0]) OUTPUT.pcap")
     exit(0)
 }
 

--- a/Sources/NIOWritePartialPCAPDemo/main.swift
+++ b/Sources/NIOWritePartialPCAPDemo/main.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import NIOCore
 import NIOPosix
 import NIOExtras
@@ -99,8 +100,8 @@ class SendSimpleSequenceRequestHandler: ChannelInboundHandler {
     }
 }
 
-guard let outputFile = CommandLine.arguments.dropFirst().first else {
-    print("Usage: \(CommandLine.arguments[0]) OUTPUT.pcap")
+guard let outputFile = ProcessInfo.processInfo.arguments.dropFirst().first else {
+    print("Usage: \(ProcessInfo.processInfo.arguments[0]) OUTPUT.pcap")
     exit(0)
 }
 

--- a/Tests/NIOExtrasTests/RequestResponseWithIDHandlerTest.swift
+++ b/Tests/NIOExtrasTests/RequestResponseWithIDHandlerTest.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded
 import NIOExtras
@@ -240,16 +241,16 @@ class RequestResponseWithIDHandlerTest: XCTestCase {
                     (ValueWithRequestID(requestID: 1, value: IOData.byteBuffer(ByteBuffer(string: "hi"))), responsePromise)
                     ),
                                       promise: writePromise)
-                var writePromiseCompleted = false
+                let writePromiseCompleted = NIOLockedValueBox(false)
                 defer {
-                    XCTAssertTrue(writePromiseCompleted)
+                    XCTAssertTrue(writePromiseCompleted.withLockedValue { $0 })
                 }
-                var responsePromiseCompleted = false
+                let responsePromiseCompleted = NIOLockedValueBox(false)
                 defer {
-                    XCTAssertTrue(responsePromiseCompleted)
+                    XCTAssertTrue(responsePromiseCompleted.withLockedValue { $0 })
                 }
                 writePromise.futureResult.whenComplete { result in
-                    writePromiseCompleted = true
+                    writePromiseCompleted.withLockedValue { $0 = true }
                     switch result {
                     case .success:
                         XCTFail("shouldn't succeed")
@@ -258,7 +259,7 @@ class RequestResponseWithIDHandlerTest: XCTestCase {
                     }
                 }
                 responsePromise.futureResult.whenComplete { result in
-                    responsePromiseCompleted = true
+                    responsePromiseCompleted.withLockedValue { $0 = true }
                     switch result {
                     case .success:
                         XCTFail("shouldn't succeed")

--- a/Tests/NIONFS3Tests/NFS3FileSystemTests.swift
+++ b/Tests/NIONFS3Tests/NFS3FileSystemTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 final class NFS3FileSystemTests: XCTestCase {
     func testReadDirDefaultImplementation() throws {
-        class MyOnlyReadDirPlusFS: NFS3FileSystemNoAuth {
+        final class MyOnlyReadDirPlusFS: NFS3FileSystemNoAuth {
             func shutdown(promise: EventLoopPromise<Void>) {
                 promise.succeed(())
             }


### PR DESCRIPTION
This PR fixes Sendability warnings present when enabling strict concurrency checking.

### Motivation:

We want to make sure `swift-nio-extras` is free of concurrency bugs, and thus removing Sendability warnings is crucial.

### Modifications:

Some types have been made Sendable, and in other places either patterns have been changed to ensure we're not crossing concurrency domains, or values have been wrapped with `NIOLoopBound` when we know we're on a specific EL.

### Result:

No more warnings in `swift-nio-extras`.