### PR TITLE
Changes for Musl support.

### DIFF
--- a/Sources/NIOExtras/DebugInboundEventsHandler.swift
+++ b/Sources/NIOExtras/DebugInboundEventsHandler.swift
@@ -13,6 +13,8 @@
 //===----------------------------------------------------------------------===//
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Musl)
+import Musl
 #else
 import Glibc
 #endif

--- a/Sources/NIOExtras/DebugOutboundEventsHandler.swift
+++ b/Sources/NIOExtras/DebugOutboundEventsHandler.swift
@@ -14,6 +14,8 @@
 
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Musl)
+import Musl
 #else
 import Glibc
 #endif

--- a/Sources/NIOExtras/WritePCAPHandler.swift
+++ b/Sources/NIOExtras/WritePCAPHandler.swift
@@ -14,6 +14,8 @@
 
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Musl)
+import Musl
 #else
 import Glibc
 #endif

--- a/Sources/NIOSOCKS/Messages/SOCKSRequest.swift
+++ b/Sources/NIOSOCKS/Messages/SOCKSRequest.swift
@@ -14,6 +14,8 @@
 
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Musl)
+import Musl
 #else
 import Glibc
 #endif


### PR DESCRIPTION
Make sure we import `Musl` rather than `Glibc`.

### Motivation:

We want NIO to build against Musl.

### Modifications:

Added a smattering of `import Musl`s.

### Result:

swift-nio-extras will build against Musl.
