### PR TITLE
Add retroactive marker to test conformances

### DIFF
--- a/Tests/NIOExtrasTests/DebugInboundEventsHandlerTest.swift
+++ b/Tests/NIOExtrasTests/DebugInboundEventsHandlerTest.swift
@@ -97,7 +97,7 @@ class DebugInboundEventsHandlerTest: XCTestCase {
     
 }
 
-extension DebugInboundEventsHandler.Event: Equatable {
+extension DebugInboundEventsHandler.Event {
     public static func == (lhs: DebugInboundEventsHandler.Event, rhs: DebugInboundEventsHandler.Event) -> Bool {
         switch (lhs, rhs) {
         case (.registered, .registered):
@@ -123,3 +123,14 @@ extension DebugInboundEventsHandler.Event: Equatable {
         }
     }
 }
+
+#if swift(>=5.8)
+#if $RetroactiveAttribute
+extension DebugInboundEventsHandler.Event: @retroactive Equatable { }
+#else
+extension DebugInboundEventsHandler.Event: Equatable { }
+#endif
+#else
+extension DebugInboundEventsHandler.Event: Equatable { }
+#endif
+

--- a/Tests/NIOExtrasTests/DebugOutboundEventsHandlerTest.swift
+++ b/Tests/NIOExtrasTests/DebugOutboundEventsHandlerTest.swift
@@ -85,7 +85,7 @@ class DebugOutboundEventsHandlerTest: XCTestCase {
 
 }
 
-extension DebugOutboundEventsHandler.Event: Equatable {
+extension DebugOutboundEventsHandler.Event {
     public static func == (lhs: DebugOutboundEventsHandler.Event, rhs: DebugOutboundEventsHandler.Event) -> Bool {
         switch (lhs, rhs) {
         case (.register, .register):
@@ -108,6 +108,15 @@ extension DebugOutboundEventsHandler.Event: Equatable {
             return false
         }
     }
-    
 }
+
+#if swift(>=5.8)
+#if $RetroactiveAttribute
+extension DebugOutboundEventsHandler.Event: @retroactive Equatable { }
+#else
+extension DebugOutboundEventsHandler.Event: Equatable { }
+#endif
+#else
+extension DebugOutboundEventsHandler.Event: Equatable { }
+#endif
 


### PR DESCRIPTION
Motivation

Nightly CI builds require annotations on retroactive conformances.
We have a few used only in tests, which are totally safe.

Modifications

Add retroactive conformance marker.

Result

Nightly CI works again