### PR TITLE
Add missing availability guards in tests

### DIFF
--- a/Tests/NIOExtrasTests/SynchronizedFileSinkTests.swift
+++ b/Tests/NIOExtrasTests/SynchronizedFileSinkTests.swift
@@ -65,6 +65,7 @@ fileprivate func withTemporaryFile<T>(content: String? = nil, _ body: (NIOCore.N
     return try body(fileHandle, temporaryFilePath)
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 fileprivate func withTemporaryFile<T>(content: String? = nil, _ body: (NIOCore.NIOFileHandle, String) async throws -> T) async throws -> T {
     let temporaryFilePath = "\(temporaryDirectory)/nio_extras_\(UUID())"
     FileManager.default.createFile(atPath: temporaryFilePath, contents: content?.data(using: .utf8))


### PR DESCRIPTION
## Motivation

Some of the test code was missing availability guards for Apple platforms, resulting in build failures for these platforms, e.g.

```
error: Concurrency is only available in iOS 13.0.0 or newer
```

## Modifications

Add missing availability guard to async function.

## Result

Tests can now build and run on iOS and other Apple platforms.