### PR TITLE
Make HTTP type conversion code public

### DIFF
--- a/Sources/NIOHTTPTypesHTTP1/HTTPTypeConversion.swift
+++ b/Sources/NIOHTTPTypesHTTP1/HTTPTypeConversion.swift
@@ -15,10 +15,23 @@
 import HTTPTypes
 import NIOHTTP1
 
-public enum HTTP1TypeConversionError: Error {
-    case invalidMethod
-    case missingPath
-    case invalidStatusCode
+public struct HTTP1TypeConversionError: Error, Equatable {
+    private enum Internal {
+        case invalidMethod
+        case missingPath
+        case invalidStatusCode
+    }
+    private let value: Internal
+    private init(_ value: Internal) {
+        self.value = value
+    }
+
+    /// Failed to create HTTPRequest.Method from HTTPMethod
+    public static var invalidMethod: Self { .init(.invalidMethod)}
+    /// Failed to extract a path from HTTPRequest
+    public static var missingPath: Self { .init(.missingPath)}
+    /// HTTPResponseHead had an invalid status code
+    public static var invalidStatusCode: Self { .init(.invalidStatusCode)}
 }
 
 extension HTTPMethod {

--- a/Sources/NIOHTTPTypesHTTP1/HTTPTypeConversion.swift
+++ b/Sources/NIOHTTPTypesHTTP1/HTTPTypeConversion.swift
@@ -15,14 +15,14 @@
 import HTTPTypes
 import NIOHTTP1
 
-private enum HTTP1TypeConversionError: Error {
+public enum HTTP1TypeConversionError: Error {
     case invalidMethod
     case missingPath
     case invalidStatusCode
 }
 
 extension HTTPMethod {
-    init(_ newMethod: HTTPRequest.Method) {
+    public init(_ newMethod: HTTPRequest.Method) {
         switch newMethod {
         case .get: self = .GET
         case .head: self = .HEAD
@@ -68,7 +68,7 @@ extension HTTPMethod {
 }
 
 extension HTTPRequest.Method {
-    init(_ oldMethod: HTTPMethod) throws {
+    public init(_ oldMethod: HTTPMethod) throws {
         switch oldMethod {
         case .GET: self = .get
         case .PUT: self = .put
@@ -114,14 +114,14 @@ extension HTTPRequest.Method {
 }
 
 extension HTTPHeaders {
-    init(_ newFields: HTTPFields) {
+    public init(_ newFields: HTTPFields) {
         let fields = newFields.map { ($0.name.rawName, $0.value) }
         self.init(fields)
     }
 }
 
 extension HTTPFields {
-    init(_ oldHeaders: HTTPHeaders, splitCookie: Bool) {
+    public init(_ oldHeaders: HTTPHeaders, splitCookie: Bool) {
         self.init()
         self.reserveCapacity(count)
         var firstHost = true
@@ -144,7 +144,7 @@ extension HTTPFields {
 }
 
 extension HTTPRequestHead {
-    init(_ newRequest: HTTPRequest) throws {
+    public init(_ newRequest: HTTPRequest) throws {
         guard let path = newRequest.method == .connect ? newRequest.authority : newRequest.path else {
             throw HTTP1TypeConversionError.missingPath
         }
@@ -174,7 +174,7 @@ extension HTTPRequestHead {
 }
 
 extension HTTPRequest {
-    init(_ oldRequest: HTTPRequestHead, secure: Bool, splitCookie: Bool) throws {
+    public init(_ oldRequest: HTTPRequestHead, secure: Bool, splitCookie: Bool) throws {
         let method = try Method(oldRequest.method)
         let scheme = secure ? "https" : "http"
         let authority = oldRequest.headers["Host"].first
@@ -189,7 +189,7 @@ extension HTTPRequest {
 }
 
 extension HTTPResponseHead {
-    init(_ newResponse: HTTPResponse) {
+    public init(_ newResponse: HTTPResponse) {
         self.init(
             version: .http1_1,
             status: HTTPResponseStatus(
@@ -202,7 +202,7 @@ extension HTTPResponseHead {
 }
 
 extension HTTPResponse {
-    init(_ oldResponse: HTTPResponseHead) throws {
+    public init(_ oldResponse: HTTPResponseHead) throws {
         guard oldResponse.status.code <= 999 else {
             throw HTTP1TypeConversionError.invalidStatusCode
         }


### PR DESCRIPTION
Make NIOHTTP1 -> HTTPTypes and vice versa conversion code public

### Motivation:

WebSocket APIs still use NIOHTTP1 types which means any library that wants to use the new types has to write a conversion step. Also OpenAPI runtime uses new HTTP types while both the server transports that are published use old NIOHTTP1 types. It is probably better that there is one place where this conversion code lives.