### PR TITLE
Fix NIOHTTPDecompression bug for multi-request channels

### DIFF
--- a/Sources/NIOHTTPCompression/HTTPDecompression.swift
+++ b/Sources/NIOHTTPCompression/HTTPDecompression.swift
@@ -129,6 +129,7 @@ public enum NIOHTTPDecompression {
             self.stream.zalloc = nil
             self.stream.zfree = nil
             self.stream.opaque = nil
+            self.inflated = 0
 
             let rc = CNIOExtrasZlib_inflateInit2(&self.stream, encoding.window)
             guard rc == Z_OK else {


### PR DESCRIPTION
Fix NIOHTTPDecompression bug for multi-request channels

### Motivation:

`NIOHTTPDecompression` erroneously accumulates decompressed data sizes across multiple requests in a single channel, leading to unwarranted `DecompressionError.limit` errors. This affects applications using persistent connections, as the decompression limits are improperly enforced. This change aims to address and rectify this issue.

### Modifications:

- Add initialization of `inflated` within `Decompressor.initializeDecoder`. 
- Introduced new tests to validate decompression functionality across multiple requests on the same channel

### Result:

This fix ensures each request's decompression size is independently considered, eliminating incorrect limit errors, and enhancing reliability for applications using HTTP compression with persistent connections.