### PR TITLE
Use `oldHeaders.count` when reserving capacity in HTTPFields

### DIFF
--- a/Sources/NIOHTTPTypesHTTP1/HTTPTypeConversion.swift
+++ b/Sources/NIOHTTPTypesHTTP1/HTTPTypeConversion.swift
@@ -136,7 +136,7 @@ extension HTTPHeaders {
 extension HTTPFields {
     public init(_ oldHeaders: HTTPHeaders, splitCookie: Bool) {
         self.init()
-        self.reserveCapacity(count)
+        self.reserveCapacity(oldHeaders.count)
         var firstHost = true
         for field in oldHeaders {
             if firstHost && field.name.lowercased() == "host" {


### PR DESCRIPTION
Fixes use of `reserveCapacity` on HTTPFields

### Motivation:

Speed.

### Modifications:

-

### Result:

Less reallocs.
