### PR TITLE
HTTP Compression Test with 304 Not Modified Responses

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -164,7 +164,7 @@ let package = Package(
         .library(name: "NIOHTTPTypesHTTP2", targets: ["NIOHTTPTypesHTTP2"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.67.0"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.27.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-http-types", from: "1.0.0"),

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
@@ -660,6 +660,34 @@ class HTTPResponseCompressorTest: XCTestCase {
             }
         }
     }
+
+    func testBypassCompressionWhenNotModified() throws {
+        let channel = EmbeddedChannel()
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseCompressor()).wait())
+        defer {
+            XCTAssertNoThrow(try channel.finish())
+        }
+
+        try sendRequest(acceptEncoding: "deflate;q=2.2, gzip;q=0.3", channel: channel)
+
+        let head = HTTPResponseHead(
+            version: .init(major: 1, minor: 1),
+            status: .notModified,
+            headers: .init()
+        )
+        try channel.writeOutbound(HTTPServerResponsePart.head(head))
+        try channel.writeOutbound(HTTPServerResponsePart.end(nil))
+
+        while let part = try channel.readOutbound(as: HTTPServerResponsePart.self) {
+            switch part {
+            case .head(let head):
+                XCTAssertEqual(head.headers[canonicalForm: "content-encoding"], [])
+            case .body:
+                XCTFail("Unexpected body")
+            case .end: break
+            }
+        }
+    }
 }
 
 extension EventLoopFuture {


### PR DESCRIPTION
Added a test for responding with 304 Not Modified with HTTP compression.

### Motivation:

https://github.com/apple/swift-nio/pull/2737 fixes an issue where the compressor would return invalid content if compression was enabled and a cached resource was returned. This adds a test to prevent regression.

### Modifications:

Added a test that checks 304 Not Modified responses have no content applied to them. Note that this test will fail until https://github.com/apple/swift-nio/pull/2737 is merged in.

### Result:

A better compression experience for everyone!

### Depends on:
- https://github.com/apple/swift-nio/pull/2737
