### PR TITLE
support h2 stream resets through user events

### DIFF
--- a/Sources/NIOHTTPTypesHTTP2/HTTP2ToHTTPCodec.swift
+++ b/Sources/NIOHTTPTypesHTTP2/HTTP2ToHTTPCodec.swift
@@ -292,4 +292,12 @@ public struct HTTP2FramePayloadToHTTPEvent {
     public static func reset(code: HTTP2ErrorCode) -> Self {
         .init(kind: .reset(code))
     }
+
+    /// Returns reset code if the event is a reset
+    public func reset() -> HTTP2ErrorCode? {
+        if case let .reset(code) = self.kind {
+            return code
+        }
+        return nil
+    }
 }

--- a/Tests/NIOHTTPTypesHTTP2Tests/NIOHTTPTypesHTTP2Tests.swift
+++ b/Tests/NIOHTTPTypesHTTP2Tests/NIOHTTPTypesHTTP2Tests.swift
@@ -116,9 +116,16 @@ final class NIOHTTPTypesHTTP2Tests: XCTestCase {
 
         try self.channel.writeOutbound(HTTPRequestPart.head(Self.request))
         try self.channel.writeOutbound(HTTPRequestPart.end(Self.trailers))
+        try self.channel.triggerUserOutboundEvent(HTTP2FramePayloadToHTTPEvent.reset(code: .enhanceYourCalm)).wait()
 
         XCTAssertEqual(try self.channel.readOutbound(as: HTTP2Frame.FramePayload.self)?.headers, Self.oldRequest)
         XCTAssertEqual(try self.channel.readOutbound(as: HTTP2Frame.FramePayload.self)?.headers, Self.oldTrailers)
+        switch try self.channel.readOutbound(as: HTTP2Frame.FramePayload.self) {
+            case .rstStream(.enhanceYourCalm):
+                break
+            default:
+                XCTFail("expected reset")
+        }
 
         try self.channel.writeInbound(HTTP2Frame.FramePayload(headers: Self.oldResponse))
         try self.channel.writeInbound(HTTP2Frame.FramePayload(headers: Self.oldTrailers))
@@ -142,9 +149,16 @@ final class NIOHTTPTypesHTTP2Tests: XCTestCase {
 
         try self.channel.writeOutbound(HTTPResponsePart.head(Self.response))
         try self.channel.writeOutbound(HTTPResponsePart.end(Self.trailers))
+        try self.channel.triggerUserOutboundEvent(HTTP2FramePayloadToHTTPEvent.reset(code: .enhanceYourCalm)).wait()
 
         XCTAssertEqual(try self.channel.readOutbound(as: HTTP2Frame.FramePayload.self)?.headers, Self.oldResponse)
         XCTAssertEqual(try self.channel.readOutbound(as: HTTP2Frame.FramePayload.self)?.headers, Self.oldTrailers)
+        switch try self.channel.readOutbound(as: HTTP2Frame.FramePayload.self) {
+            case .rstStream(.enhanceYourCalm):
+                break
+            default:
+                XCTFail("expected reset")
+        }
 
         XCTAssertTrue(try self.channel.finish().isClean)
     }

--- a/Tests/NIOHTTPTypesHTTP2Tests/NIOHTTPTypesHTTP2Tests.swift
+++ b/Tests/NIOHTTPTypesHTTP2Tests/NIOHTTPTypesHTTP2Tests.swift
@@ -116,15 +116,15 @@ final class NIOHTTPTypesHTTP2Tests: XCTestCase {
 
         try self.channel.writeOutbound(HTTPRequestPart.head(Self.request))
         try self.channel.writeOutbound(HTTPRequestPart.end(Self.trailers))
-        try self.channel.triggerUserOutboundEvent(HTTP2FramePayloadToHTTPEvent.reset(code: .enhanceYourCalm)).wait()
+        try self.channel.triggerUserOutboundEvent(NIOHTTP2FramePayloadToHTTPEvent.reset(code: .enhanceYourCalm)).wait()
 
         XCTAssertEqual(try self.channel.readOutbound(as: HTTP2Frame.FramePayload.self)?.headers, Self.oldRequest)
         XCTAssertEqual(try self.channel.readOutbound(as: HTTP2Frame.FramePayload.self)?.headers, Self.oldTrailers)
         switch try self.channel.readOutbound(as: HTTP2Frame.FramePayload.self) {
-            case .rstStream(.enhanceYourCalm):
-                break
-            default:
-                XCTFail("expected reset")
+        case .rstStream(.enhanceYourCalm):
+            break
+        default:
+            XCTFail("expected reset")
         }
 
         try self.channel.writeInbound(HTTP2Frame.FramePayload(headers: Self.oldResponse))
@@ -149,15 +149,15 @@ final class NIOHTTPTypesHTTP2Tests: XCTestCase {
 
         try self.channel.writeOutbound(HTTPResponsePart.head(Self.response))
         try self.channel.writeOutbound(HTTPResponsePart.end(Self.trailers))
-        try self.channel.triggerUserOutboundEvent(HTTP2FramePayloadToHTTPEvent.reset(code: .enhanceYourCalm)).wait()
+        try self.channel.triggerUserOutboundEvent(NIOHTTP2FramePayloadToHTTPEvent.reset(code: .enhanceYourCalm)).wait()
 
         XCTAssertEqual(try self.channel.readOutbound(as: HTTP2Frame.FramePayload.self)?.headers, Self.oldResponse)
         XCTAssertEqual(try self.channel.readOutbound(as: HTTP2Frame.FramePayload.self)?.headers, Self.oldTrailers)
         switch try self.channel.readOutbound(as: HTTP2Frame.FramePayload.self) {
-            case .rstStream(.enhanceYourCalm):
-                break
-            default:
-                XCTFail("expected reset")
+        case .rstStream(.enhanceYourCalm):
+            break
+        default:
+            XCTFail("expected reset")
         }
 
         XCTAssertTrue(try self.channel.finish().isClean)


### PR DESCRIPTION
Allow applications to trigger HTTP/2 stream resets while using NIOHTTPTypesHTTP2's codecs

### Motivation:

Resetting streams with specific error codes is required by some applications such as those implementing the CONNECT method
(see https://datatracker.ietf.org/doc/html/rfc9113#section-8.5-8). Unfortunately, the HTTP2ToHTTP codecs don't expose this capability to applications.

### Modifications:

Introduce an outbound user event applications can trigger when needing to reset an HTTP/2 stream.

### Result:

Now applications can trigger HTTP/2 stream resets while using the codecs provided by NIOHTTPTypesHTTP2
