### PR TITLE
Android support

### DIFF
--- a/Sources/NIOExtras/DebugInboundEventsHandler.swift
+++ b/Sources/NIOExtras/DebugInboundEventsHandler.swift
@@ -17,6 +17,8 @@ import NIOCore
 import Darwin
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #else
 import Glibc
 #endif

--- a/Sources/NIOExtras/DebugOutboundEventsHandler.swift
+++ b/Sources/NIOExtras/DebugOutboundEventsHandler.swift
@@ -18,6 +18,8 @@ import NIOCore
 import Darwin
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #else
 import Glibc
 #endif

--- a/Sources/NIOExtras/WritePCAPHandler.swift
+++ b/Sources/NIOExtras/WritePCAPHandler.swift
@@ -20,6 +20,8 @@ import NIOCore
 import Darwin
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #else
 import Glibc
 #endif

--- a/Sources/NIOSOCKS/Messages/SOCKSRequest.swift
+++ b/Sources/NIOSOCKS/Messages/SOCKSRequest.swift
@@ -19,6 +19,8 @@ import NIOCore
 import Darwin
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #else
 import Glibc
 #endif

--- a/Tests/NIOExtrasTests/SynchronizedFileSinkTests.swift
+++ b/Tests/NIOExtrasTests/SynchronizedFileSinkTests.swift
@@ -102,6 +102,8 @@ private func withTemporaryFile<T>(
 private var temporaryDirectory: String {
     #if os(Linux)
     return "/tmp"
+    #elseif os(Android)
+    return "/data/local/tmp"
     #else
     if #available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, *) {
         return FileManager.default.temporaryDirectory.path

--- a/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
+++ b/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
@@ -16,11 +16,12 @@ import Foundation
 import NIOCore
 import NIOEmbedded
 import XCTest
+
+@testable import NIOExtras
+
 #if canImport(Android)
 import Android
 #endif
-
-@testable import NIOExtras
 
 class WritePCAPHandlerTest: XCTestCase {
     private var accumulatedPackets: [ByteBuffer]!

--- a/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
+++ b/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
@@ -16,6 +16,9 @@ import Foundation
 import NIOCore
 import NIOEmbedded
 import XCTest
+#if canImport(Android)
+import Android
+#endif
 
 @testable import NIOExtras
 


### PR DESCRIPTION
Add Android support

### Motivation:

Support the Android platform.

### Modifications:

Add Android imports and fix the default temporary directory to be correct for the OS.

### Result:

The package will build and test on Android.