### PR TITLE
Fix warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -211,7 +211,7 @@ let package = Package(
         .library(name: "NIOResumableUpload", targets: ["NIOResumableUpload"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.67.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.78.0"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.27.0"),
         .package(url: "https://github.com/apple/swift-http-types.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-http-structured-headers.git", from: "1.1.0"),

--- a/Sources/NIOExtras/HTTP1ProxyConnectHandler.swift
+++ b/Sources/NIOExtras/HTTP1ProxyConnectHandler.swift
@@ -241,7 +241,7 @@ public final class NIOHTTP1ProxyConnectHandler: ChannelDuplexHandler, RemovableC
         }
 
         // Ok, we've set up the proxy connection. We can now remove ourselves, which should happen synchronously.
-        context.pipeline.removeHandler(context: context, promise: nil)
+        context.pipeline.syncOperations.removeHandler(context: context, promise: nil)
 
         self.promise?.succeed(())
     }

--- a/Sources/NIOExtras/WritePCAPHandler.swift
+++ b/Sources/NIOExtras/WritePCAPHandler.swift
@@ -738,7 +738,7 @@ extension NIOWritePCAPHandler {
                 }
             }
             return SynchronizedFileSink(
-                fileHandle: NIOFileHandle(descriptor: fd),
+                fileHandle: NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: fd),
                 errorHandler: errorHandler
             )
         }

--- a/Sources/NIOExtrasPerformanceTester/HTTP1PCAPPerformanceTests.swift
+++ b/Sources/NIOExtrasPerformanceTester/HTTP1PCAPPerformanceTests.swift
@@ -37,11 +37,13 @@ class HTTP1ThreadedPCapPerformanceTest: HTTP1ThreadedPerformanceTest {
     init() {
         let sinkHolder = SinkHolder()
         func addPCap(channel: Channel) -> EventLoopFuture<Void> {
-            let pcapHandler = NIOWritePCAPHandler(
-                mode: .client,
-                fileSink: sinkHolder.fileSink.write
-            )
-            return channel.pipeline.addHandler(pcapHandler, position: .first)
+            channel.eventLoop.submit {
+                let pcapHandler = NIOWritePCAPHandler(
+                    mode: .client,
+                    fileSink: sinkHolder.fileSink.write
+                )
+                return try channel.pipeline.syncOperations.addHandler(pcapHandler, position: .first)
+            }
         }
 
         self.sinkHolder = sinkHolder

--- a/Sources/NIOExtrasPerformanceTester/HTTP1PerformanceTestFramework.swift
+++ b/Sources/NIOExtrasPerformanceTester/HTTP1PerformanceTestFramework.swift
@@ -193,8 +193,8 @@ class HTTP1ThreadedPerformanceTest: Benchmark {
 
             var writeFutures: [EventLoopFuture<Void>] = []
             for clientChannel in clientChannels {
-                clientChannel.write(NIOAny(HTTPClientRequestPart.head(self.head)), promise: nil)
-                writeFutures.append(clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))))
+                clientChannel.write(HTTPClientRequestPart.head(self.head), promise: nil)
+                writeFutures.append(clientChannel.writeAndFlush(HTTPClientRequestPart.end(nil)))
             }
             let allWrites = EventLoopFuture<Void>.andAllComplete(writeFutures, on: writeFutures.first!.eventLoop)
             try! allWrites.wait()

--- a/Sources/NIOExtrasPerformanceTester/HTTP1RollingPCAPPerformanceTests.swift
+++ b/Sources/NIOExtrasPerformanceTester/HTTP1RollingPCAPPerformanceTests.swift
@@ -18,15 +18,17 @@ import NIOExtras
 class HTTP1ThreadedRollingPCapPerformanceTest: HTTP1ThreadedPerformanceTest {
     init() {
         func addRollingPCap(channel: Channel) -> EventLoopFuture<Void> {
-            let pcapRingBuffer = NIOPCAPRingBuffer(
-                maximumFragments: 25,
-                maximumBytes: 1_000_000
-            )
-            let pcapHandler = NIOWritePCAPHandler(
-                mode: .client,
-                fileSink: pcapRingBuffer.addFragment
-            )
-            return channel.pipeline.addHandler(pcapHandler, position: .first)
+            channel.eventLoop.submit {
+                let pcapRingBuffer = NIOPCAPRingBuffer(
+                    maximumFragments: 25,
+                    maximumBytes: 1_000_000
+                )
+                let pcapHandler = NIOWritePCAPHandler(
+                    mode: .client,
+                    fileSink: pcapRingBuffer.addFragment
+                )
+                try channel.pipeline.syncOperations.addHandler(pcapHandler, position: .first)
+            }
         }
 
         super.init(

--- a/Sources/NIOExtrasPerformanceTester/PCAPPerformanceTest.swift
+++ b/Sources/NIOExtrasPerformanceTester/PCAPPerformanceTest.swift
@@ -53,7 +53,7 @@ final class PCAPPerformanceTest: Benchmark {
             mode: .client,
             fileSink: fileSink.write
         )
-        try channel.pipeline.addHandler(pcapHandler, position: .first).wait()
+        try channel.pipeline.syncOperations.addHandler(pcapHandler, position: .first)
 
         for _ in 0..<self.numberOfRepeats {
             channel.writeAndFlush(self.byteBuffer, promise: nil)

--- a/Sources/NIOExtrasPerformanceTester/RollingPCAPPerformanceTest.swift
+++ b/Sources/NIOExtrasPerformanceTester/RollingPCAPPerformanceTest.swift
@@ -45,7 +45,7 @@ final class RollingPCAPPerformanceTest: Benchmark {
             mode: .client,
             fileSink: pcapRingBuffer.addFragment
         )
-        try channel.pipeline.addHandler(pcapHandler, position: .first).wait()
+        try channel.pipeline.syncOperations.addHandler(pcapHandler, position: .first)
 
         for _ in 0..<self.numberOfRepeats {
             channel.writeAndFlush(self.byteBuffer, promise: nil)

--- a/Sources/NIOResumableUpload/HTTPResumableUploadChannel.swift
+++ b/Sources/NIOResumableUpload/HTTPResumableUploadChannel.swift
@@ -221,7 +221,7 @@ extension HTTPResumableUploadChannel {
 
     func receive(_ part: HTTPRequestPart) {
         self.eventLoop.preconditionInEventLoop()
-        self.pipeline.fireChannelRead(NIOAny(part))
+        self.pipeline.fireChannelRead(part)
     }
 
     func receiveComplete() {

--- a/Sources/NIOSOCKSClient/main.swift
+++ b/Sources/NIOSOCKSClient/main.swift
@@ -32,10 +32,11 @@ let targetAddress = SOCKSAddress.address(try SocketAddress(ipAddress: targetIPAd
 let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: elg)
     .channelInitializer { channel in
-        channel.pipeline.addHandlers([
-            SOCKSClientHandler(targetAddress: targetAddress),
-            EchoHandler(),
-        ])
+        channel.eventLoop.makeCompletedFuture {
+            let sync = channel.pipeline.syncOperations
+            try sync.addHandler(SOCKSClientHandler(targetAddress: targetAddress))
+            try sync.addHandler(EchoHandler())
+        }
     }
 let channel = try bootstrap.connect(host: "127.0.0.1", port: 1080).wait()
 

--- a/Tests/NIOExtrasTests/DebugInboundEventsHandlerTest.swift
+++ b/Tests/NIOExtrasTests/DebugInboundEventsHandlerTest.swift
@@ -29,7 +29,7 @@ class DebugInboundEventsHandlerTest: XCTestCase {
         handlerUnderTest = DebugInboundEventsHandler { event, _ in
             self.lastEvent = event
         }
-        try? channel.pipeline.addHandler(handlerUnderTest).wait()
+        try? channel.pipeline.syncOperations.addHandlers(handlerUnderTest)
     }
 
     override func tearDown() {
@@ -90,9 +90,8 @@ class DebugInboundEventsHandlerTest: XCTestCase {
         let messageString = "message"
         var expectedBuffer = ByteBufferAllocator().buffer(capacity: messageString.count)
         expectedBuffer.setString(messageString, at: 0)
-        let nioAny = NIOAny(expectedBuffer)
-        channel.pipeline.fireChannelRead(nioAny)
-        XCTAssertEqual(lastEvent, .read(data: nioAny))
+        channel.pipeline.fireChannelRead(expectedBuffer)
+        XCTAssertEqual(lastEvent, .read(data: NIOAny(expectedBuffer)))
     }
 
 }

--- a/Tests/NIOExtrasTests/DebugOutboundEventsHandlerTest.swift
+++ b/Tests/NIOExtrasTests/DebugOutboundEventsHandlerTest.swift
@@ -29,7 +29,7 @@ class DebugOutboundEventsHandlerTest: XCTestCase {
         handlerUnderTest = DebugOutboundEventsHandler { event, _ in
             self.lastEvent = event
         }
-        try? channel.pipeline.addHandler(handlerUnderTest).wait()
+        try? channel.pipeline.syncOperations.addHandler(handlerUnderTest)
     }
 
     override func tearDown() {
@@ -57,9 +57,9 @@ class DebugOutboundEventsHandlerTest: XCTestCase {
     }
 
     func testWrite() {
-        let data = NIOAny(" 1 2 3 ")
-        channel.write(data, promise: nil)
-        XCTAssertEqual(lastEvent, .write(data: data))
+        let data = " 1 2 3 "
+        channel.write(" 1 2 3 ", promise: nil)
+        XCTAssertEqual(lastEvent, .write(data: NIOAny(data)))
     }
 
     func testFlush() {

--- a/Tests/NIOExtrasTests/FixedLengthFrameDecoderTest.swift
+++ b/Tests/NIOExtrasTests/FixedLengthFrameDecoderTest.swift
@@ -23,7 +23,9 @@ class FixedLengthFrameDecoderTest: XCTestCase {
         let channel = EmbeddedChannel()
 
         let frameLength = 8
-        try channel.pipeline.addHandler(ByteToMessageHandler(FixedLengthFrameDecoder(frameLength: frameLength))).wait()
+        try channel.pipeline.syncOperations.addHandler(
+            ByteToMessageHandler(FixedLengthFrameDecoder(frameLength: frameLength))
+        )
 
         var buffer = channel.allocator.buffer(capacity: frameLength)
         buffer.writeString("xxxx")
@@ -43,7 +45,9 @@ class FixedLengthFrameDecoderTest: XCTestCase {
         let channel = EmbeddedChannel()
 
         let frameLength = 8
-        try channel.pipeline.addHandler(ByteToMessageHandler(FixedLengthFrameDecoder(frameLength: frameLength))).wait()
+        try channel.pipeline.syncOperations.addHandler(
+            ByteToMessageHandler(FixedLengthFrameDecoder(frameLength: frameLength))
+        )
 
         var buffer = channel.allocator.buffer(capacity: 19)
         buffer.writeString("xxxxxxxxaaaaaaaabbb")
@@ -78,7 +82,7 @@ class FixedLengthFrameDecoderTest: XCTestCase {
 
         let frameLength = 8
         let handler = ByteToMessageHandler(FixedLengthFrameDecoder(frameLength: frameLength))
-        try channel.pipeline.addHandler(handler).wait()
+        try channel.pipeline.syncOperations.addHandler(handler)
 
         var buffer = channel.allocator.buffer(capacity: 15)
         buffer.writeString("xxxxxxxxxxxxxxx")
@@ -91,7 +95,7 @@ class FixedLengthFrameDecoderTest: XCTestCase {
             }
         )
 
-        let removeFuture = channel.pipeline.removeHandler(handler)
+        let removeFuture = channel.pipeline.syncOperations.removeHandler(handler)
         (channel.eventLoop as! EmbeddedEventLoop).run()
         XCTAssertNoThrow(try removeFuture.wait())
         XCTAssertThrowsError(try channel.throwIfErrorCaught()) { error in
@@ -112,7 +116,7 @@ class FixedLengthFrameDecoderTest: XCTestCase {
 
         let frameLength = 8
         let handler = ByteToMessageHandler(FixedLengthFrameDecoder(frameLength: frameLength))
-        try channel.pipeline.addHandler(handler).wait()
+        try channel.pipeline.syncOperations.addHandler(handler)
 
         var buffer = channel.allocator.buffer(capacity: 6)
         buffer.writeString("xxxxxxxx")
@@ -125,7 +129,7 @@ class FixedLengthFrameDecoderTest: XCTestCase {
             }
         )
 
-        let removeFuture = channel.pipeline.removeHandler(handler)
+        let removeFuture = channel.pipeline.syncOperations.removeHandler(handler)
         (channel.eventLoop as! EmbeddedEventLoop).run()
         XCTAssertNoThrow(try removeFuture.wait())
         XCTAssertNoThrow(try channel.throwIfErrorCaught())

--- a/Tests/NIOExtrasTests/HTTP1ProxyConnectHandlerTests.swift
+++ b/Tests/NIOExtrasTests/HTTP1ProxyConnectHandlerTests.swift
@@ -221,16 +221,16 @@ class HTTP1ProxyConnectHandlerTests: XCTestCase {
         )
         var promises: [EventLoopPromise<Void>] = []
         promises.append(embedded.eventLoop.makePromise())
-        embedded.pipeline.write(NIOAny(HTTPClientRequestPart.head(requestHead)), promise: promises.last)
+        embedded.pipeline.write(HTTPClientRequestPart.head(requestHead), promise: promises.last)
 
         promises.append(embedded.eventLoop.makePromise())
         embedded.pipeline.write(
-            NIOAny(HTTPClientRequestPart.body(.byteBuffer(ByteBuffer(string: "Test")))),
+            HTTPClientRequestPart.body(.byteBuffer(ByteBuffer(string: "Test"))),
             promise: promises.last
         )
 
         promises.append(embedded.eventLoop.makePromise())
-        embedded.pipeline.write(NIOAny(HTTPClientRequestPart.end(nil)), promise: promises.last)
+        embedded.pipeline.write(HTTPClientRequestPart.end(nil), promise: promises.last)
         embedded.pipeline.flush()
 
         // read the connect header back
@@ -291,16 +291,16 @@ class HTTP1ProxyConnectHandlerTests: XCTestCase {
         let requestHead = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "apple.com")
         var promises: [EventLoopPromise<Void>] = []
         promises.append(embedded.eventLoop.makePromise())
-        embedded.pipeline.write(NIOAny(HTTPClientRequestPart.head(requestHead)), promise: promises.last)
+        embedded.pipeline.write(HTTPClientRequestPart.head(requestHead), promise: promises.last)
 
         promises.append(embedded.eventLoop.makePromise())
         embedded.pipeline.write(
-            NIOAny(HTTPClientRequestPart.body(.byteBuffer(ByteBuffer(string: "Test")))),
+            HTTPClientRequestPart.body(.byteBuffer(ByteBuffer(string: "Test"))),
             promise: promises.last
         )
 
         promises.append(embedded.eventLoop.makePromise())
-        embedded.pipeline.write(NIOAny(HTTPClientRequestPart.end(nil)), promise: promises.last)
+        embedded.pipeline.write(HTTPClientRequestPart.end(nil), promise: promises.last)
         embedded.pipeline.flush()
 
         // read the connect header back

--- a/Tests/NIOExtrasTests/JSONRPCFramingContentLengthHeaderDecoderTests.swift
+++ b/Tests/NIOExtrasTests/JSONRPCFramingContentLengthHeaderDecoderTests.swift
@@ -25,9 +25,9 @@ final class JSONRPCFramingContentLengthHeaderDecoderTests: XCTestCase {
 
         // let's add the framing handler to the pipeline as that's what we're testing here.
         XCTAssertNoThrow(
-            try self.channel.pipeline.addHandler(
+            try self.channel.pipeline.syncOperations.addHandler(
                 ByteToMessageHandler(NIOJSONRPCFraming.ContentLengthHeaderFrameDecoder())
-            ).wait()
+            )
         )
         // this pretends to connect the channel to this IP address.
         XCTAssertNoThrow(self.channel.connect(to: try .init(ipAddress: "1.2.3.4", port: 5678)))

--- a/Tests/NIOExtrasTests/JSONRPCFramingContentLengthHeaderEncoderTests.swift
+++ b/Tests/NIOExtrasTests/JSONRPCFramingContentLengthHeaderEncoderTests.swift
@@ -25,13 +25,13 @@ final class JSONRPCFramingContentLengthHeaderEncoderTests: XCTestCase {
 
         // let's add the framing handler to the pipeline as that's what we're testing here.
         XCTAssertNoThrow(
-            try self.channel.pipeline.addHandler(NIOJSONRPCFraming.ContentLengthHeaderFrameEncoder()).wait()
+            try self.channel.pipeline.syncOperations.addHandler(NIOJSONRPCFraming.ContentLengthHeaderFrameEncoder())
         )
         // let's also add the decoder so we can round-trip
         XCTAssertNoThrow(
-            try self.channel.pipeline.addHandler(
+            try self.channel.pipeline.syncOperations.addHandler(
                 ByteToMessageHandler(NIOJSONRPCFraming.ContentLengthHeaderFrameDecoder())
-            ).wait()
+            )
         )
         // this pretends to connect the channel to this IP address.
         XCTAssertNoThrow(self.channel.connect(to: try .init(ipAddress: "1.2.3.4", port: 5678)))

--- a/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest.swift
+++ b/Tests/NIOExtrasTests/LengthFieldBasedFrameDecoderTest.swift
@@ -62,15 +62,15 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
             XCTAssertEqual(buffer.read24UInt(endianness: .little), input)
         }
     }
-    func testDecodeWithUInt8HeaderWithData() throws {
 
+    func testDecodeWithUInt8HeaderWithData() throws {
         self.decoderUnderTest = .init(
             LengthFieldBasedFrameDecoder(
                 lengthFieldLength: .one,
                 lengthFieldEndianness: .little
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let dataBytes: [UInt8] = [10, 20, 30, 40]
         let dataBytesLengthHeader = UInt8(dataBytes.count)
@@ -100,7 +100,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .little
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let dataLength: UInt16 = 5
 
@@ -129,7 +129,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .big
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         var buffer = self.channel.allocator.buffer(capacity: 8)  // 3 byte header + 5 character string
         buffer.writeBytes([0, 0, 5])
@@ -156,7 +156,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .little
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let dataLength: UInt32 = 5
 
@@ -185,7 +185,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .little
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let dataLength: UInt64 = 5
 
@@ -214,7 +214,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .little
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let dataLength: Int64 = 5
 
@@ -244,7 +244,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .big
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let dataLength: Int64 = 5
 
@@ -269,7 +269,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
     func testDecodeWithInt64HeaderStringDefaultingToBigEndian() throws {
 
         self.decoderUnderTest = .init(LengthFieldBasedFrameDecoder(lengthFieldLength: .eight))
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let dataLength: Int64 = 5
 
@@ -298,7 +298,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .little
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let firstFrameDataLength: UInt8 = 5
         let secondFrameDataLength: UInt8 = 3
@@ -341,7 +341,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .little
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let frameDataLength: UInt16 = 5
 
@@ -400,7 +400,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .little
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let buffer = self.channel.allocator.buffer(capacity: 1)
         XCTAssertTrue(try self.channel.writeInbound(buffer).isEmpty)
@@ -415,7 +415,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .little
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let dataLength: UInt8 = 5  // 8 byte is only half the length required
 
@@ -440,7 +440,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .little
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let dataLength: UInt16 = 7
 
@@ -469,7 +469,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .little
             )
         )
-        try? self.channel.pipeline.addHandler(self.decoderUnderTest).wait()
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let dataLength: Int64 = 5
 
@@ -479,7 +479,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
 
         XCTAssertTrue(try self.channel.writeInbound(buffer).isFull)
 
-        let removeFuture = self.channel.pipeline.removeHandler(self.decoderUnderTest)
+        let removeFuture = self.channel.pipeline.syncOperations.removeHandler(self.decoderUnderTest)
         (channel.eventLoop as! EmbeddedEventLoop).run()
         XCTAssertNoThrow(try removeFuture.wait())
 
@@ -503,7 +503,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .little
             )
         )
-        try? self.channel.pipeline.addHandler(self.decoderUnderTest).wait()
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let extraUnusedDataString = "fghi"
         let dataLength: Int64 = 5
@@ -514,7 +514,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
 
         XCTAssertTrue(try channel.writeInbound(buffer).isFull)
 
-        let removeFuture = self.channel.pipeline.removeHandler(self.decoderUnderTest)
+        let removeFuture = self.channel.pipeline.syncOperations.removeHandler(self.decoderUnderTest)
         (channel.eventLoop as! EmbeddedEventLoop).run()
         XCTAssertNoThrow(try removeFuture.wait())
 
@@ -664,7 +664,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .little
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let dataLength = UInt32(Int32.max)
 
@@ -682,7 +682,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .little
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let dataLength = UInt32(Int32.max) + 1
 
@@ -700,7 +700,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .little
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let dataLength = UInt64(Int32.max)
 
@@ -718,7 +718,7 @@ class LengthFieldBasedFrameDecoderTest: XCTestCase {
                 lengthFieldEndianness: .little
             )
         )
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.decoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.decoderUnderTest))
 
         let dataLength = UInt64(Int32.max) + 1
 

--- a/Tests/NIOExtrasTests/LengthFieldPrependerTest.swift
+++ b/Tests/NIOExtrasTests/LengthFieldPrependerTest.swift
@@ -45,7 +45,7 @@ class LengthFieldPrependerTest: XCTestCase {
             lengthFieldEndianness: .little
         )
 
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.encoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.encoderUnderTest))
 
         let dataBytes: [UInt8] = [10, 20, 30, 40]
 
@@ -85,7 +85,7 @@ class LengthFieldPrependerTest: XCTestCase {
             lengthFieldEndianness: endianness
         )
 
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.encoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.encoderUnderTest))
 
         var buffer = self.channel.allocator.buffer(capacity: standardDataStringCount)
         buffer.writeString(standardDataString)
@@ -129,7 +129,7 @@ class LengthFieldPrependerTest: XCTestCase {
             lengthFieldEndianness: endianness
         )
 
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.encoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.encoderUnderTest))
 
         var buffer = self.channel.allocator.buffer(capacity: standardDataStringCount)
         buffer.writeString(standardDataString)
@@ -173,7 +173,7 @@ class LengthFieldPrependerTest: XCTestCase {
             lengthFieldEndianness: endianness
         )
 
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.encoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.encoderUnderTest))
 
         var buffer = self.channel.allocator.buffer(capacity: standardDataStringCount)
         buffer.writeString(standardDataString)
@@ -217,7 +217,7 @@ class LengthFieldPrependerTest: XCTestCase {
             lengthFieldEndianness: endianness
         )
 
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.encoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.encoderUnderTest))
 
         var buffer = self.channel.allocator.buffer(capacity: standardDataStringCount)
         buffer.writeString(standardDataString)
@@ -258,7 +258,7 @@ class LengthFieldPrependerTest: XCTestCase {
             lengthFieldEndianness: endianness
         )
 
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.encoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.encoderUnderTest))
 
         var buffer = self.channel.allocator.buffer(capacity: standardDataStringCount)
         buffer.writeString(standardDataString)
@@ -302,7 +302,7 @@ class LengthFieldPrependerTest: XCTestCase {
             lengthFieldEndianness: endianness
         )
 
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.encoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.encoderUnderTest))
 
         var buffer = self.channel.allocator.buffer(capacity: standardDataStringCount)
         buffer.writeString(standardDataString)
@@ -341,7 +341,7 @@ class LengthFieldPrependerTest: XCTestCase {
 
         self.encoderUnderTest = LengthFieldPrepender(lengthFieldLength: .eight)
 
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.encoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.encoderUnderTest))
 
         var buffer = self.channel.allocator.buffer(capacity: standardDataStringCount)
         buffer.writeString(standardDataString)
@@ -385,7 +385,7 @@ class LengthFieldPrependerTest: XCTestCase {
             lengthFieldEndianness: endianness
         )
 
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.encoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.encoderUnderTest))
 
         let buffer = self.channel.allocator.buffer(capacity: 0)
 
@@ -421,7 +421,7 @@ class LengthFieldPrependerTest: XCTestCase {
             lengthFieldEndianness: endianness
         )
 
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.encoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.encoderUnderTest))
 
         let contents = [UInt8](repeating: 200, count: 514)
 
@@ -465,7 +465,7 @@ class LengthFieldPrependerTest: XCTestCase {
             lengthFieldEndianness: endianness
         )
 
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.encoderUnderTest).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.encoderUnderTest))
 
         let contents = [UInt8](repeating: 200, count: 300)
 

--- a/Tests/NIOExtrasTests/LineBasedFrameDecoderTest.swift
+++ b/Tests/NIOExtrasTests/LineBasedFrameDecoderTest.swift
@@ -28,7 +28,7 @@ class LineBasedFrameDecoderTest: XCTestCase {
         self.channel = EmbeddedChannel()
         self.decoder = LineBasedFrameDecoder()
         self.handler = ByteToMessageHandler(self.decoder)
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.handler).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(self.handler))
     }
 
     override func tearDown() {
@@ -69,7 +69,7 @@ class LineBasedFrameDecoderTest: XCTestCase {
         XCTAssertEqual(3, outputBuffer?.readableBytes)
         XCTAssertEqual("foo", outputBuffer?.readString(length: 3))
 
-        let removeFuture = self.channel.pipeline.removeHandler(self.handler)
+        let removeFuture = self.channel.pipeline.syncOperations.removeHandler(self.handler)
         (self.channel.eventLoop as! EmbeddedEventLoop).run()
         XCTAssertNoThrow(try removeFuture.wait())
         XCTAssertThrowsError(try self.channel.throwIfErrorCaught()) { error in
@@ -93,7 +93,7 @@ class LineBasedFrameDecoderTest: XCTestCase {
         var outputBuffer: ByteBuffer? = try self.channel.readInbound()
         XCTAssertEqual("foo", outputBuffer?.readString(length: 3))
 
-        let removeFuture = self.channel.pipeline.removeHandler(self.handler)
+        let removeFuture = self.channel.pipeline.syncOperations.removeHandler(self.handler)
         (self.channel.eventLoop as! EmbeddedEventLoop).run()
         XCTAssertNoThrow(try removeFuture.wait())
         XCTAssertNoThrow(try self.channel.throwIfErrorCaught())

--- a/Tests/NIOExtrasTests/PCAPRingBufferTest.swift
+++ b/Tests/NIOExtrasTests/PCAPRingBufferTest.swift
@@ -126,14 +126,14 @@ class PCAPRingBufferTest: XCTestCase {
         let channel = EmbeddedChannel()
         let ringBuffer = NIOPCAPRingBuffer(maximumFragments: .init(fragmentsToRecord), maximumBytes: 1_000_000)
         XCTAssertNoThrow(
-            try channel.pipeline.addHandler(
+            try channel.pipeline.syncOperations.addHandler(
                 NIOWritePCAPHandler(
                     mode: .client,
                     fakeLocalAddress: nil,
                     fakeRemoteAddress: nil,
                     fileSink: { ringBuffer.addFragment($0) }
                 )
-            ).wait()
+            )
         )
         channel.localAddress = try! SocketAddress(ipAddress: "255.255.255.254", port: Int(UInt16.max) - 1)
         XCTAssertNoThrow(try channel.connect(to: .init(ipAddress: "1.2.3.4", port: 5678)).wait())

--- a/Tests/NIOExtrasTests/QuiescingHelperTest.swift
+++ b/Tests/NIOExtrasTests/QuiescingHelperTest.swift
@@ -70,7 +70,7 @@ public class QuiescingHelperTest: XCTestCase {
             XCTAssertNoThrow(try channel.connect(to: .init(ipAddress: "1.2.3.4", port: pretendPort)).wait())
             waitForFutures.append(waitForPromise.futureResult)
             childChannels.append(channel)
-            serverChannel.pipeline.fireChannelRead(NIOAny(channel))
+            serverChannel.pipeline.fireChannelRead(channel)
         }
         // check that the server channel and all child channels are active before initiating the shutdown
         XCTAssertTrue(serverChannel.isActive)
@@ -201,7 +201,7 @@ public class QuiescingHelperTest: XCTestCase {
         let childChannel1 = EmbeddedChannel(handler: eventCounterHandler, loop: el)
         // activate the child channel
         XCTAssertNoThrow(try childChannel1.connect(to: .init(ipAddress: "1.2.3.4", port: 1)).wait())
-        serverChannel.pipeline.fireChannelRead(NIOAny(childChannel1))
+        serverChannel.pipeline.fireChannelRead(childChannel1)
 
         // check that the server channel and channel are active before initiating the shutdown
         XCTAssertTrue(serverChannel.isActive)
@@ -244,7 +244,7 @@ public class QuiescingHelperTest: XCTestCase {
         let childChannel1 = EmbeddedChannel(handler: WaitForQuiesceUserEvent(promise: waitForPromise1), loop: el)
         // activate the child channel
         XCTAssertNoThrow(try childChannel1.connect(to: .init(ipAddress: "1.2.3.4", port: 1)).wait())
-        serverChannel.pipeline.fireChannelRead(NIOAny(childChannel1))
+        serverChannel.pipeline.fireChannelRead(childChannel1)
 
         el.run()
 
@@ -260,7 +260,7 @@ public class QuiescingHelperTest: XCTestCase {
         let childChannel2 = EmbeddedChannel(handler: WaitForQuiesceUserEvent(promise: waitForPromise2), loop: el)
         // activate the child channel
         XCTAssertNoThrow(try childChannel2.connect(to: .init(ipAddress: "1.2.3.4", port: 2)).wait())
-        serverChannel.pipeline.fireChannelRead(NIOAny(childChannel2))
+        serverChannel.pipeline.fireChannelRead(childChannel2)
         el.run()
 
         // Check that we got all quiescing events
@@ -308,7 +308,7 @@ public class QuiescingHelperTest: XCTestCase {
         let childChannel1 = EmbeddedChannel(loop: el)
         // activate the child channel
         XCTAssertNoThrow(try childChannel1.connect(to: .init(ipAddress: "1.2.3.4", port: 1)).wait())
-        serverChannel.pipeline.fireChannelRead(NIOAny(childChannel1))
+        serverChannel.pipeline.fireChannelRead(childChannel1)
 
         el.run()
     }

--- a/Tests/NIOExtrasTests/RequestResponseHandlerTest.swift
+++ b/Tests/NIOExtrasTests/RequestResponseHandlerTest.swift
@@ -41,7 +41,7 @@ class RequestResponseHandlerTest: XCTestCase {
     }
 
     func testSimpleRequestWorks() {
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(RequestResponseHandler<IOData, String>()).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(RequestResponseHandler<IOData, String>()))
         self.buffer.writeString("hello")
 
         // pretend to connect to the EmbeddedChannel knows it's supposed to be active
@@ -62,7 +62,7 @@ class RequestResponseHandlerTest: XCTestCase {
 
     func testEnqueingMultipleRequestsWorks() throws {
         struct DummyError: Error {}
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(RequestResponseHandler<IOData, Int>()).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(RequestResponseHandler<IOData, Int>()))
 
         var futures: [EventLoopFuture<Int>] = []
         // pretend to connect to the EmbeddedChannel knows it's supposed to be active
@@ -114,7 +114,7 @@ class RequestResponseHandlerTest: XCTestCase {
 
     func testRequestsEnqueuedAfterErrorAreFailed() {
         struct DummyError: Error {}
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(RequestResponseHandler<IOData, Void>()).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(RequestResponseHandler<IOData, Void>()))
 
         self.channel.pipeline.fireErrorCaught(DummyError())
 
@@ -131,7 +131,7 @@ class RequestResponseHandlerTest: XCTestCase {
         struct DummyError1: Error {}
         struct DummyError2: Error {}
 
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(RequestResponseHandler<IOData, Void>()).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(RequestResponseHandler<IOData, Void>()))
 
         let p: EventLoopPromise<Void> = self.eventLoop.makePromise()
         // right now, everything's still okay so the enqueued request won't immediately be failed
@@ -152,7 +152,7 @@ class RequestResponseHandlerTest: XCTestCase {
     }
 
     func testClosedConnectionFailsOutstandingPromises() {
-        XCTAssertNoThrow(try self.channel.pipeline.addHandler(RequestResponseHandler<String, Void>()).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(RequestResponseHandler<String, Void>()))
 
         let promise = self.eventLoop.makePromise(of: Void.self)
         XCTAssertNoThrow(try self.channel.writeOutbound(("Hello!", promise)))

--- a/Tests/NIOExtrasTests/SynchronizedFileSinkTests.swift
+++ b/Tests/NIOExtrasTests/SynchronizedFileSinkTests.swift
@@ -72,7 +72,7 @@ private func withTemporaryFile<T>(
         XCTAssertNoThrow(try FileManager.default.removeItem(atPath: temporaryFilePath))
     }
 
-    let fileHandle = try NIOFileHandle(path: temporaryFilePath, mode: [.read, .write])
+    let fileHandle = try NIOFileHandle(_deprecatedPath: temporaryFilePath, mode: [.read, .write])
     defer {
         XCTAssertNoThrow(try fileHandle.close())
     }
@@ -91,7 +91,13 @@ private func withTemporaryFile<T>(
         XCTAssertNoThrow(try FileManager.default.removeItem(atPath: temporaryFilePath))
     }
 
-    let fileHandle = try NIOFileHandle(path: temporaryFilePath, mode: [.read, .write])
+    // NIOFileHandle(_deprecatedPath:mode:) is 'noasync' but we don't have a viable alternative;
+    // this wrapper suppresses the 'noasync'.
+    func makeFileHandle() throws -> NIOFileHandle {
+        try NIOFileHandle(_deprecatedPath: temporaryFilePath, mode: [.read, .write])
+    }
+
+    let fileHandle = try makeFileHandle()
     defer {
         XCTAssertNoThrow(try fileHandle.close())
     }

--- a/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
+++ b/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
@@ -49,7 +49,7 @@ class WritePCAPHandlerTest: XCTestCase {
         self.accumulatedPackets = []
         self.channel = EmbeddedChannel()
         XCTAssertNoThrow(
-            try self.channel.pipeline.addHandler(
+            try self.channel.pipeline.syncOperations.addHandler(
                 NIOWritePCAPHandler(
                     mode: .client,
                     fakeLocalAddress: nil,
@@ -59,7 +59,7 @@ class WritePCAPHandlerTest: XCTestCase {
                     }
                 ),
                 name: "NIOWritePCAPHandler"
-            ).wait()
+            )
         )
         self.scratchBuffer = self.channel.allocator.buffer(capacity: 128)
     }
@@ -731,7 +731,7 @@ class WritePCAPHandlerTest: XCTestCase {
         XCTAssertNoThrow(try self.channel.pipeline.removeHandler(name: "NIOWritePCAPHandler").wait())
         let settings = NIOWritePCAPHandler.Settings(emitPCAPWrites: .whenIssued)
         XCTAssertNoThrow(
-            try self.channel.pipeline.addHandler(
+            try self.channel.pipeline.syncOperations.addHandler(
                 NIOWritePCAPHandler(
                     mode: .client,
                     fakeLocalAddress: nil,
@@ -741,7 +741,7 @@ class WritePCAPHandlerTest: XCTestCase {
                         self.accumulatedPackets.append($0)
                     }
                 )
-            ).wait()
+            )
         )
         self.channel.localAddress = try! SocketAddress(ipAddress: "1.2.3.4", port: 1111)
         self.channel.remoteAddress = try! SocketAddress(ipAddress: "9.8.7.6", port: 2222)
@@ -779,7 +779,7 @@ class WritePCAPHandlerTest: XCTestCase {
         // Let's drop all writes/flushes so EmbeddedChannel won't accumulate them.
         XCTAssertNoThrow(try channel.pipeline.addHandler(DropAllWritesAndFlushes()).wait())
         XCTAssertNoThrow(
-            try channel.pipeline.addHandler(
+            try channel.pipeline.syncOperations.addHandler(
                 NIOWritePCAPHandler(
                     mode: .client,
                     fakeLocalAddress: .init(ipAddress: "::1", port: 1),
@@ -788,7 +788,7 @@ class WritePCAPHandlerTest: XCTestCase {
                         numberOfBytesLogged += Int64($0.readableBytes)
                     }
                 )
-            ).wait()
+            )
         )
         // Let's also drop all channelReads to prevent accumulation of all the data.
         XCTAssertNoThrow(try channel.pipeline.addHandler(DropAllChannelReads()).wait())

--- a/Tests/NIOHTTPCompressionTests/HTTPRequestDecompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPRequestDecompressorTest.swift
@@ -44,8 +44,8 @@ private final class DecompressedAssert: ChannelInboundHandler {
 class HTTPRequestDecompressorTest: XCTestCase {
     func testDecompressionNoLimit() throws {
         let channel = EmbeddedChannel()
-        try channel.pipeline.addHandler(NIOHTTPRequestDecompressor(limit: .none)).wait()
-        try channel.pipeline.addHandler(DecompressedAssert()).wait()
+        try channel.pipeline.syncOperations.addHandler(NIOHTTPRequestDecompressor(limit: .none))
+        try channel.pipeline.syncOperations.addHandler(DecompressedAssert())
 
         let buffer = ByteBuffer.of(string: testString)
         let compressed = compress(buffer, "gzip")
@@ -67,7 +67,7 @@ class HTTPRequestDecompressorTest: XCTestCase {
 
     func testDecompressionLimitRatio() throws {
         let channel = EmbeddedChannel()
-        try channel.pipeline.addHandler(NIOHTTPRequestDecompressor(limit: .ratio(10))).wait()
+        try channel.pipeline.syncOperations.addHandler(NIOHTTPRequestDecompressor(limit: .ratio(10)))
         let decompressed = ByteBuffer.of(bytes: Array(repeating: 0, count: 500))
         let compressed = compress(decompressed, "gzip")
         let headers = HTTPHeaders([("Content-Encoding", "gzip"), ("Content-Length", "\(compressed.readableBytes)")])
@@ -100,7 +100,9 @@ class HTTPRequestDecompressorTest: XCTestCase {
         let channel = EmbeddedChannel()
         let decompressed = ByteBuffer.of(bytes: Array(repeating: 0, count: 200))
         let compressed = compress(decompressed, "gzip")
-        try channel.pipeline.addHandler(NIOHTTPRequestDecompressor(limit: .size(decompressed.readableBytes - 1))).wait()
+        try channel.pipeline.syncOperations.addHandler(
+            NIOHTTPRequestDecompressor(limit: .size(decompressed.readableBytes - 1))
+        )
         let headers = HTTPHeaders([("Content-Encoding", "gzip"), ("Content-Length", "\(compressed.readableBytes)")])
         try channel.writeInbound(
             HTTPServerRequestPart.head(
@@ -129,7 +131,7 @@ class HTTPRequestDecompressorTest: XCTestCase {
 
     func testDecompression() throws {
         let channel = EmbeddedChannel()
-        try channel.pipeline.addHandler(NIOHTTPRequestDecompressor(limit: .none)).wait()
+        try channel.pipeline.syncOperations.addHandler(NIOHTTPRequestDecompressor(limit: .none))
 
         let body = Array(repeating: testString, count: 1000).joined()
         let algorithms: [(actual: String, announced: String)?] = [
@@ -174,7 +176,7 @@ class HTTPRequestDecompressorTest: XCTestCase {
         let compressed = ByteBuffer(bytes: [120, 156, 99, 0, 0, 0, 1, 0, 1] + [1, 2, 3])
 
         let channel = EmbeddedChannel()
-        try channel.pipeline.addHandler(NIOHTTPRequestDecompressor(limit: .none)).wait()
+        try channel.pipeline.syncOperations.addHandler(NIOHTTPRequestDecompressor(limit: .none))
         let headers = HTTPHeaders([("Content-Encoding", "deflate"), ("Content-Length", "\(compressed.readableBytes)")])
         try channel.writeInbound(
             HTTPServerRequestPart.head(
@@ -195,7 +197,7 @@ class HTTPRequestDecompressorTest: XCTestCase {
         let compressed = ByteBuffer(bytes: [120, 156, 99, 0])
 
         let channel = EmbeddedChannel()
-        try channel.pipeline.addHandler(NIOHTTPRequestDecompressor(limit: .none)).wait()
+        try channel.pipeline.syncOperations.addHandler(NIOHTTPRequestDecompressor(limit: .none))
         let headers = HTTPHeaders([("Content-Encoding", "deflate"), ("Content-Length", "\(compressed.readableBytes)")])
         try channel.writeInbound(
             HTTPServerRequestPart.head(

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest.swift
@@ -23,7 +23,7 @@ import XCTest
 class HTTPResponseDecompressorTest: XCTestCase {
     func testDecompressionNoLimit() throws {
         let channel = EmbeddedChannel()
-        try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .none)).wait()
+        try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .none))
 
         let headers = HTTPHeaders([("Content-Encoding", "deflate"), ("Content-Length", "13")])
         try channel.writeInbound(
@@ -36,7 +36,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
 
     func testDecompressionLimitSizeWithContentLenghtHeaderSucceeds() {
         let channel = EmbeddedChannel()
-        XCTAssertNoThrow(try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .size(272))).wait())
+        XCTAssertNoThrow(try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .size(272))))
 
         let headers = HTTPHeaders([("Content-Encoding", "deflate"), ("Content-Length", "13")])
 
@@ -53,7 +53,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
 
     func testDecompressionLimitSizeWithContentLenghtHeaderFails() {
         let channel = EmbeddedChannel()
-        XCTAssertNoThrow(try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .size(271))).wait())
+        XCTAssertNoThrow(try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .size(271))))
 
         let headers = HTTPHeaders([("Content-Encoding", "deflate"), ("Content-Length", "13")])
 
@@ -72,7 +72,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
 
     func testDecompressionLimitSizeWithoutContentLenghtHeaderSucceeds() {
         let channel = EmbeddedChannel()
-        XCTAssertNoThrow(try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .size(272))).wait())
+        XCTAssertNoThrow(try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .size(272))))
 
         let headers = HTTPHeaders([("Content-Encoding", "deflate")])
 
@@ -89,7 +89,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
 
     func testDecompressionLimitSizeWithoutContentLenghtHeaderFails() {
         let channel = EmbeddedChannel()
-        XCTAssertNoThrow(try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .size(271))).wait())
+        XCTAssertNoThrow(try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .size(271))))
 
         let headers = HTTPHeaders([("Content-Encoding", "deflate")])
 
@@ -108,7 +108,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
 
     func testDecompressionLimitRatioWithContentLenghtHeaderSucceeds() {
         let channel = EmbeddedChannel()
-        XCTAssertNoThrow(try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .ratio(21))).wait())
+        XCTAssertNoThrow(try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .ratio(21))))
 
         let headers = HTTPHeaders([("Content-Encoding", "deflate"), ("Content-Length", "13")])
 
@@ -125,7 +125,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
 
     func testDecompressionLimitRatioWithContentLenghtHeaderFails() {
         let channel = EmbeddedChannel()
-        XCTAssertNoThrow(try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .ratio(20))).wait())
+        XCTAssertNoThrow(try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .ratio(20))))
 
         let headers = HTTPHeaders([("Content-Encoding", "deflate"), ("Content-Length", "13")])
 
@@ -144,7 +144,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
 
     func testDecompressionLimitRatioWithoutContentLenghtHeaderSucceeds() {
         let channel = EmbeddedChannel()
-        XCTAssertNoThrow(try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .ratio(21))).wait())
+        XCTAssertNoThrow(try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .ratio(21))))
 
         let headers = HTTPHeaders([("Content-Encoding", "deflate")])
 
@@ -161,7 +161,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
 
     func testDecompressionLimitRatioWithoutContentLenghtHeaderFails() {
         let channel = EmbeddedChannel()
-        XCTAssertNoThrow(try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .ratio(20))).wait())
+        XCTAssertNoThrow(try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .ratio(20))))
 
         let headers = HTTPHeaders([("Content-Encoding", "deflate")])
 
@@ -180,7 +180,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
 
     func testDecompressionMultipleWriteWithLimit() {
         let channel = EmbeddedChannel()
-        XCTAssertNoThrow(try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .size(272))).wait())
+        XCTAssertNoThrow(try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .size(272))))
 
         let headers = HTTPHeaders([("Content-Encoding", "deflate")])
         // this compressed payload is 272 bytes long uncompressed
@@ -202,7 +202,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
 
     func testDecompression() {
         let channel = EmbeddedChannel()
-        XCTAssertNoThrow(try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .none)).wait())
+        XCTAssertNoThrow(try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .none)))
 
         var body = ""
         for _ in 1...1000 {
@@ -266,7 +266,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
 
     func testDecompressionWithoutContentLength() {
         let channel = EmbeddedChannel()
-        XCTAssertNoThrow(try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .none)).wait())
+        XCTAssertNoThrow(try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .none)))
 
         var body = ""
         for _ in 1...1000 {
@@ -336,7 +336,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
         let compressed = ByteBuffer(bytes: [120, 156, 99, 0, 0, 0, 1, 0, 1] + [1, 2, 3])
 
         let channel = EmbeddedChannel()
-        try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .none)).wait()
+        try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .none))
         let headers = HTTPHeaders([("Content-Encoding", "deflate"), ("Content-Length", "\(compressed.readableBytes)")])
         try channel.writeInbound(
             HTTPClientResponsePart.head(.init(version: .init(major: 1, minor: 1), status: .ok, headers: headers))
@@ -350,7 +350,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
         let compressed = ByteBuffer(bytes: [120, 156, 99, 0])
 
         let channel = EmbeddedChannel()
-        try channel.pipeline.addHandler(NIOHTTPResponseDecompressor(limit: .none)).wait()
+        try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .none))
         let headers = HTTPHeaders([("Content-Encoding", "deflate"), ("Content-Length", "\(compressed.readableBytes)")])
         try channel.writeInbound(
             HTTPClientResponsePart.head(.init(version: .init(major: 1, minor: 1), status: .ok, headers: headers))

--- a/Tests/NIOSOCKSTests/SOCKSServerHandshakeHandler+Tests.swift
+++ b/Tests/NIOSOCKSTests/SOCKSServerHandshakeHandler+Tests.swift
@@ -243,7 +243,7 @@ class SOCKSServerHandlerTests: XCTestCase {
     func testFlushOnHandlerRemoved() {
         self.writeInbound([0x05, 0x01])
         self.assertInbound([])
-        XCTAssertNoThrow(try self.channel.pipeline.removeHandler(self.handler).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.removeHandler(self.handler).wait())
         self.assertInbound([0x05, 0x01])
     }
 

--- a/Tests/NIOSOCKSTests/SocksClientHandler+Tests.swift
+++ b/Tests/NIOSOCKSTests/SocksClientHandler+Tests.swift
@@ -235,7 +235,7 @@ class SocksClientHandlerTests: XCTestCase {
         self.assertOutputBuffer([])
 
         // add the handler, there should be outbound data immediately
-        XCTAssertNoThrow(self.channel.pipeline.addHandler(handler))
+        XCTAssertNoThrow(try self.channel.pipeline.syncOperations.addHandler(handler))
         self.assertOutputBuffer([0x05, 0x01, 0x00])
     }
 
@@ -263,7 +263,7 @@ class SocksClientHandlerTests: XCTestCase {
         let establishPromise = self.channel.eventLoop.makePromise(of: Void.self)
         let removalPromise = self.channel.eventLoop.makePromise(of: Void.self)
         establishPromise.futureResult.whenSuccess { _ in
-            self.channel.pipeline.removeHandler(self.handler).cascade(to: removalPromise)
+            self.channel.pipeline.syncOperations.removeHandler(self.handler).cascade(to: removalPromise)
         }
 
         XCTAssertNoThrow(
@@ -309,7 +309,7 @@ class SocksClientHandlerTests: XCTestCase {
 
         // we try to remove the handler before the connection is established.
         let removalPromise = self.channel.eventLoop.makePromise(of: Void.self)
-        self.channel.pipeline.removeHandler(self.handler, promise: removalPromise)
+        self.channel.pipeline.syncOperations.removeHandler(self.handler, promise: removalPromise)
 
         // establishes the connection
         self.writeInbound([0x05, 0x00, 0x00, 0x01, 192, 168, 1, 1, 0x00, 0x50])


### PR DESCRIPTION
Motivation:

The latest NIO release deprecated a number of APIs and added more Sendable contraints.

Modifications:

- Use sync APIs where possible
- Use `_deprecated` but not `@deprecated` NIOFileHandle API
- Stop using NIOAny

Result:

No warnings