### PR TITLE
Avoid integer overrun in NIOHTTPResponsiveness

### DIFF
--- a/Sources/NIOHTTPResponsiveness/ResponsivenessConfig.swift
+++ b/Sources/NIOHTTPResponsiveness/ResponsivenessConfig.swift
@@ -33,7 +33,11 @@ public struct ResponsivenessConfigURLs: Codable, Hashable, Sendable {
         case uploadURL = "upload_url"
     }
 
-    static var largeDownloadSize: Int { 8 * 1_000_000_000 }  // 8 * 10^9
+    #if _pointerBitWidth(_32)
+    static var largeDownloadSize: Int { 1_000_000_000 }  // 1 * 10^9
+    #else
+    static var largeDownloadSize: Int { 8_000_000_000 }  // 8 * 10^9
+    #endif
     static var smallDownloadSize: Int { 1 }
 
     public init(scheme: String, authority: String) {


### PR DESCRIPTION
We use 8*10^9 in `NIOHTTPResponsiveness` however this number will overrun the integer size on platforms with 32-bit pointer-width such as watchOS.

This change drops down to use 1*10^9 on such platforms.