### PR TITLE
Add a missing import to CNIOLinux

### DIFF
--- a/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
+++ b/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
@@ -12,11 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+import CNIOLinux
 import Foundation
 import NIOCore
 import NIOEmbedded
 import XCTest
-import CNIOLinux
 
 @testable import NIOExtras
 

--- a/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
+++ b/Tests/NIOExtrasTests/WritePCAPHandlerTest.swift
@@ -16,6 +16,7 @@ import Foundation
 import NIOCore
 import NIOEmbedded
 import XCTest
+import CNIOLinux
 
 @testable import NIOExtras
 


### PR DESCRIPTION
### Motivation:

Stricter import rules mean that using the `sin_addr` property on Linux requires the explicit CNIOLinux import.

### Modifications:

Added the missing import.

### Result:

Fixes a CI diagnostic.
