### PR TITLE
Ignore return value of signal() on Android

### DIFF
--- a/Sources/HTTPServerWithQuiescingDemo/main.swift
+++ b/Sources/HTTPServerWithQuiescingDemo/main.swift
@@ -88,7 +88,8 @@ private func runServer() throws {
 
             quiesce.initiateShutdown(promise: fullyShutdownPromise)
         }
-        signal(SIGINT, SIG_IGN)
+        // assignment needed for Android due to non-nullable return type
+        _ = signal(SIGINT, SIG_IGN)
         signalSource.resume()
 
         do {


### PR DESCRIPTION
See https://github.com/apple/swift-nio/pull/3181 and https://github.com/apple/swift-nio/issues/3180