### PR TITLE
Drop Swift 5.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ jobs:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,6 @@ jobs:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project

--- a/Tests/NIOExtrasTests/DebugInboundEventsHandlerTest.swift
+++ b/Tests/NIOExtrasTests/DebugInboundEventsHandlerTest.swift
@@ -124,7 +124,7 @@ extension DebugInboundEventsHandler.Event {
 }
 
 #if compiler(>=6.0)
-extension DebugInboundEventsHandler.Event: @retroactive Equatable {}
+extension DebugInboundEventsHandler.Event: Equatable {}
 #else
 extension DebugInboundEventsHandler.Event: Equatable {}
 #endif

--- a/Tests/NIOExtrasTests/DebugOutboundEventsHandlerTest.swift
+++ b/Tests/NIOExtrasTests/DebugOutboundEventsHandlerTest.swift
@@ -111,7 +111,7 @@ extension DebugOutboundEventsHandler.Event {
 }
 
 #if compiler(>=6.0)
-extension DebugOutboundEventsHandler.Event: @retroactive Equatable {}
+extension DebugOutboundEventsHandler.Event: Equatable {}
 #else
 extension DebugOutboundEventsHandler.Event: Equatable {}
 #endif


### PR DESCRIPTION
Motivation:

Swift 5.9 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 5.10
* Remove Swift 5.9 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
