### PR TITLE
Responsiveness fallback handler

### DIFF
--- a/Sources/NIOHTTPResponsiveness/SimpleResponsivenessRequestMux.swift
+++ b/Sources/NIOHTTPResponsiveness/SimpleResponsivenessRequestMux.swift
@@ -17,8 +17,17 @@ import HTTPTypes
 import NIOCore
 import NIOHTTPTypes
 
-/// Basic request multiplexer that identifies which request type (config, download, upload) is requested and adds the appropriate handler.
-/// Once the handler has been added, all data is passed through to the newly added handler.
+/// A basic request multiplexer that identifies which request type (config, download, upload) is requested and adds the
+/// appropriate handler. Once the handler has been added, all data is passed through to the newly added handler.
+///
+/// The multiplexer handles the following requests:
+/// - GET `/responsiveness`: Returns the configuration buffer
+/// - GET `/responsiveness/download/{size}`: Adds a handler for downloading data of the specified size
+/// - POST `/responsiveness/upload`: Adds a handler for uploading data
+/// - GET `/drip`: Adds a handler for responds with a configurable stream of zeroes
+/// 
+/// Per default other requests get a 404 response. Can be configured to accept other requests as well and forward them
+/// along the channel pipeline.
 public final class SimpleResponsivenessRequestMux: ChannelInboundHandler {
 
     public typealias InboundIn = HTTPRequestPart
@@ -27,14 +36,41 @@ public final class SimpleResponsivenessRequestMux: ChannelInboundHandler {
     // Predefine some common things we'll need in responses
     private static let notFoundBody = ByteBuffer(string: "Not Found")
 
-    // Whether or not we added a handler after us
-    private var handlerAdded = false
-
     // Config returned to user that lists responsiveness endpoints
     private let responsivenessConfigBuffer: ByteBuffer
 
+    // Whether or not to foward other requests down the channel pipeline
+    private var forwardOtherRequests: Bool
+
+    /// Initializes a new `SimpleResponsivenessRequestMux` with the provided configuration buffer.
+    ///
+    /// This initializer creates a request multiplexer that will return the provided configuration
+    /// buffer when the `/responsiveness` endpoint is accessed. All requests that don't match
+    /// the defined responsiveness endpoints will be rejected with a 404 Not Found response.
+    ///
+    /// - Parameter responsivenessConfigBuffer: A `ByteBuffer` containing the configuration information
+    ///   to be returned when the `/responsiveness` endpoint is accessed.
     public init(responsivenessConfigBuffer: ByteBuffer) {
         self.responsivenessConfigBuffer = responsivenessConfigBuffer
+        self.forwardOtherRequests = false
+    }
+
+    /// Initializes a new `SimpleResponsivenessRequestMux` with the provided configuration buffer
+    /// and request handling behavior.
+    ///
+    /// This initializer creates a request multiplexer that will return the provided configuration
+    /// buffer when the `/responsiveness` endpoint is accessed. The behavior for requests that don't
+    /// match the defined responsiveness endpoints is determined by the `forwardOtherRequests` parameter.
+    ///
+    /// - Parameters:
+    ///   - responsivenessConfigBuffer: A `ByteBuffer` containing the configuration information
+    ///     to be returned when the `/responsiveness` endpoint is accessed.
+    ///   - forwardOtherRequests: If `false`, requests that don't match the defined responsiveness
+    ///     endpoints will be rejected with a 404 Not Found response. If `true`, such requests
+    ///     will be passed down the channel pipeline for other handlers to process.
+    public init(responsivenessConfigBuffer: ByteBuffer, forwardOtherRequests: Bool) {
+        self.responsivenessConfigBuffer = responsivenessConfigBuffer
+        self.forwardOtherRequests = forwardOtherRequests
     }
 
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -99,26 +135,24 @@ public final class SimpleResponsivenessRequestMux: ChannelInboundHandler {
                     self.addHandlerOrInternalError(context: context, handler: HTTPDrippingDownloadHandler())
                 }
             default:
-                self.writeSimpleResponse(
-                    context: context,
-                    status: .notFound,
-                    body: SimpleResponsivenessRequestMux.notFoundBody
-                )
+                if !self.forwardOtherRequests {
+                    self.writeSimpleResponse(
+                        context: context,
+                        status: .notFound,
+                        body: SimpleResponsivenessRequestMux.notFoundBody
+                    )
+                    return
+                }
             }
         }
 
-        // Only pass through data through if we've actually added a handler. If we didn't add a handler, it's because we
-        // directly responded. In this case, we don't care about the rest of the request.
-        if self.handlerAdded {
-            context.fireChannelRead(data)
-        }
+        context.fireChannelRead(data)
     }
 
-    /// Adding handlers is fallible. If we fail to do it, we should return 500 to the user
+    // Adding handlers is fallible. If we fail to do it, we should return 500 to the user
     private func addHandlerOrInternalError(context: ChannelHandlerContext, handler: ChannelHandler) {
         do {
-            try context.pipeline.syncOperations.addHandler(handler)
-            self.handlerAdded = true
+            try context.pipeline.syncOperations.addHandler(handler, position: .after(self))
         } catch {
             self.writeSimpleResponse(
                 context: context,

--- a/Sources/NIOHTTPResponsiveness/SimpleResponsivenessRequestMux.swift
+++ b/Sources/NIOHTTPResponsiveness/SimpleResponsivenessRequestMux.swift
@@ -25,7 +25,7 @@ import NIOHTTPTypes
 /// - GET `/responsiveness/download/{size}`: Adds a handler for downloading data of the specified size
 /// - POST `/responsiveness/upload`: Adds a handler for uploading data
 /// - GET `/drip`: Adds a handler for responds with a configurable stream of zeroes
-/// 
+///
 /// Per default other requests get a 404 response. Can be configured to accept other requests as well and forward them
 /// along the channel pipeline.
 public final class SimpleResponsivenessRequestMux: ChannelInboundHandler {

--- a/Sources/NIOHTTPResponsiveness/SimpleResponsivenessRequestMux.swift
+++ b/Sources/NIOHTTPResponsiveness/SimpleResponsivenessRequestMux.swift
@@ -74,68 +74,10 @@ public final class SimpleResponsivenessRequestMux: ChannelInboundHandler {
     }
 
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        if case let .head(request) = self.unwrapInboundIn(data) {
-            // TODO: get rid of this altogether and instead create an empty iterator below
-            guard let path = request.path else {
-                self.writeSimpleResponse(
-                    context: context,
-                    status: .notFound,
-                    body: SimpleResponsivenessRequestMux.notFoundBody
-                )
-                return
-            }
-
-            var pathComponents = path.utf8.lazy.split(separator: UInt8(ascii: "?"), maxSplits: 1).makeIterator()
-            let firstPathComponent = pathComponents.next()!
-            let queryArgsString = pathComponents.next()
-
-            // Split the path into components
-            var uriComponentIterator = firstPathComponent.split(
-                separator: UInt8(ascii: "/"),
-                maxSplits: 3,
-                omittingEmptySubsequences: false
-            ).lazy.map(Substring.init).makeIterator()
-
-            // Handle possible path components
-            switch (
-                request.method, uriComponentIterator.next(), uriComponentIterator.next(),
-                uriComponentIterator.next(), uriComponentIterator.next().flatMap { Int($0) }
-            ) {
-            case (.get, .some(""), .some("responsiveness"), .none, .none):
-                self.writeSimpleResponse(
-                    context: context,
-                    status: .ok,
-                    body: self.responsivenessConfigBuffer
-                )
-            case (.get, .some(""), .some("responsiveness"), .some("download"), .some(let size)):
-                self.addHandlerOrInternalError(
-                    context: context,
-                    handler: HTTPDrippingDownloadHandler(count: 1, size: size)
-                )
-            case (.post, .some(""), .some("responsiveness"), .some("upload"), .none):
-                // Check if we should expect a certain count
-                var expectation: Int?
-                if let lengthHeaderValue = request.headerFields[.contentLength] {
-                    if let expectedLength = Int(lengthHeaderValue) {
-                        expectation = expectedLength
-                    }
-                }
-                self.addHandlerOrInternalError(
-                    context: context,
-                    handler: HTTPReceiveDiscardHandler(expectation: expectation)
-                )
-            case (_, .some(""), .some("drip"), .none, .none):
-                if let queryArgsString = queryArgsString {
-                    guard let handler = HTTPDrippingDownloadHandler(queryArgsString: queryArgsString) else {
-                        self.writeSimpleResponse(context: context, status: .badRequest, body: .init())
-                        return
-                    }
-                    self.addHandlerOrInternalError(context: context, handler: handler)
-                } else {
-                    self.addHandlerOrInternalError(context: context, handler: HTTPDrippingDownloadHandler())
-                }
-            default:
-                if !self.forwardOtherRequests {
+        do {
+            if case let .head(request) = self.unwrapInboundIn(data) {
+                // TODO: get rid of this altogether and instead create an empty iterator below
+                guard let path = request.path else {
                     self.writeSimpleResponse(
                         context: context,
                         status: .notFound,
@@ -143,16 +85,72 @@ public final class SimpleResponsivenessRequestMux: ChannelInboundHandler {
                     )
                     return
                 }
+
+                var pathComponents = path.utf8.lazy.split(separator: UInt8(ascii: "?"), maxSplits: 1).makeIterator()
+                let firstPathComponent = pathComponents.next()!
+                let queryArgsString = pathComponents.next()
+
+                // Split the path into components
+                var uriComponentIterator = firstPathComponent.split(
+                    separator: UInt8(ascii: "/"),
+                    maxSplits: 3,
+                    omittingEmptySubsequences: false
+                ).lazy.map(Substring.init).makeIterator()
+
+                // Handle possible path components
+                switch (
+                    request.method, uriComponentIterator.next(), uriComponentIterator.next(),
+                    uriComponentIterator.next(), uriComponentIterator.next().flatMap { Int($0) }
+                ) {
+                case (.get, .some(""), .some("responsiveness"), .none, .none):
+                    self.writeSimpleResponse(
+                        context: context,
+                        status: .ok,
+                        body: self.responsivenessConfigBuffer
+                    )
+                case (.get, .some(""), .some("responsiveness"), .some("download"), .some(let size)):
+                    try context.pipeline.syncOperations.addHandler(
+                        HTTPDrippingDownloadHandler(count: 1, size: size),
+                        position: .after(self)
+                    )
+                case (.post, .some(""), .some("responsiveness"), .some("upload"), .none):
+                    // Check if we should expect a certain count
+                    var expectation: Int?
+                    if let lengthHeaderValue = request.headerFields[.contentLength] {
+                        if let expectedLength = Int(lengthHeaderValue) {
+                            expectation = expectedLength
+                        }
+                    }
+                    try context.pipeline.syncOperations.addHandler(
+                        HTTPReceiveDiscardHandler(expectation: expectation),
+                        position: .after(self)
+                    )
+                case (_, .some(""), .some("drip"), .none, .none):
+                    if let queryArgsString = queryArgsString {
+                        guard let handler = HTTPDrippingDownloadHandler(queryArgsString: queryArgsString) else {
+                            self.writeSimpleResponse(context: context, status: .badRequest, body: .init())
+                            return
+                        }
+                        try context.pipeline.syncOperations.addHandler(handler, position: .after(self))
+                    } else {
+                        try context.pipeline.syncOperations.addHandler(
+                            HTTPDrippingDownloadHandler(),
+                            position: .after(self)
+                        )
+                    }
+                default:
+                    if !self.forwardOtherRequests {
+                        self.writeSimpleResponse(
+                            context: context,
+                            status: .notFound,
+                            body: SimpleResponsivenessRequestMux.notFoundBody
+                        )
+                        return
+                    }
+                }
             }
-        }
 
-        context.fireChannelRead(data)
-    }
-
-    // Adding handlers is fallible. If we fail to do it, we should return 500 to the user
-    private func addHandlerOrInternalError(context: ChannelHandlerContext, handler: ChannelHandler) {
-        do {
-            try context.pipeline.syncOperations.addHandler(handler, position: .after(self))
+            context.fireChannelRead(data)
         } catch {
             self.writeSimpleResponse(
                 context: context,


### PR DESCRIPTION
### Motivation:

The SimpleResponsivenessRequestMux knows how to handle a few different requests. For those it doesn’t know how to handle, it responds with a 404.

It would be helpful if the handler had a mode where it optionally forwards requests it doesn’t know how to handle to a fallback channel handler so that users can respond to these requests.

### Modifications:

The mux has a new initializer that can configure it to accept unexpected requests, i.e., those not defined by itself. In this case it will forward requests down the pipeline. However, its default behavior remains the same: respond with a 404.

### Result:

When setting up the mux, users can add additional handler to the pipeline and configure the mux to forward its requests.