### PR TITLE
Add callback in TimedCertificateReloader to listen for reloads

### DIFF
--- a/Sources/NIOCertificateReloading/TimedCertificateReloader.swift
+++ b/Sources/NIOCertificateReloading/TimedCertificateReloader.swift
@@ -100,6 +100,21 @@ import Foundation
 /// not being recognized or not matching the configured one; not being able to verify a certificate's signature against the given
 /// private key; etc), then that attempt will be aborted but the service will keep on trying at the configured interval.
 /// The last-valid certificate-key pair (if any) will be returned as the ``sslContextConfigurationOverride``.
+///
+/// Optionally, you may also observe any reloads by specifying the ``TimedCertificateReloader/Configuration/onCertificateLoaded`` parameter.
+/// This will notify you whenever a new certificate is loaded, and you will given an instance of ``TimedCertificateReloader/LoadedCertificateChainAndKeyPairDiff``.
+/// This struct contains the previous certificate and key, as well as the new ones. This is useful for example if you would like to log whenever a new certificate is loaded.
+/// ```swift
+/// let reloaderConfiguration = TimedCertificateReloader.Configuration(
+///     refreshInterval: .seconds(500),
+///     certificateSource: TimedCertificateReloader.CertificateSource(...),
+///     privateKeySource: TimedCertificateReloader.PrivateKeySource(...)
+/// ) { configuration in
+///     configuration.onCertificateLoaded = { diff in
+///         logger.info("Loaded new certificate", metadata: ["certificate": "\(diff.currentX509CertificateChain)"])
+///     }
+/// }
+/// ```
 #if compiler(>=6.0)
 @available(macOS 13, iOS 16, watchOS 9, tvOS 16, macCatalyst 16, visionOS 1, *)
 #else
@@ -283,37 +298,58 @@ public struct TimedCertificateReloader: CertificateReloader {
         var privateKey: NIOSSLPrivateKeySource
 
         var x509Certificates: [Certificate]
-        var x509Key: Certificate.PrivateKey?
+        var x509Key: Certificate.PrivateKey
     }
 
     /// Provides information about a reload.
     public struct LoadedCertificateChainAndKeyPairDiff: Sendable {
         /// The certificate chain which was being used prior to this reload. This will be nil if this is the first load.
-        public var previousCertificateChain: [Certificate]?
-        /// The private which was being used prior to this reload.  This will be nil if this is the first load.
-        public var previousPrivateKey: Certificate.PrivateKey?
+        public var previousCertificateChain: [NIOSSLCertificateSource]?
+        /// A swift-certificates representation of the certificate chain which was being used prior to this reload. This will be nil if this is the first load.
+        public var previousX509CertificateChain: [Certificate]?
+        /// The private key which was being used prior to this reload. This will be nil if this is the first load.
+        public var previousPrivateKey: NIOSSLPrivateKeySource?
+        /// A swift-certificates representation of the private key which was being used prior to this reload. This will be nil if this is the first load.
+        public var previousX509PrivateKey: Certificate.PrivateKey?
+
         /// The certificate chain which has newly been loaded.
-        public var currentCertificateChain: [Certificate]
+        public var currentCertificateChain: [NIOSSLCertificateSource]
+        /// A swift-certificates representation of the certificate chain which has newly been loaded.
+        public var currentX509CertificateChain: [Certificate]
         /// The private key which has newly been loaded.
-        public var currentPrivateKey: Certificate.PrivateKey
+        public var currentPrivateKey: NIOSSLPrivateKeySource
+        /// A swift-certificates representation of the private key which has newly been loaded.
+        public var currentX509PrivateKey: Certificate.PrivateKey
 
         /// Create a new instance.
         /// - Note: You usually do not need to create instances of this object. However, it may be useful for writing unit tests.
         /// - Parameters:
         ///   - previousCertificateChain: The certificate chain which was being used prior to this reload. This will be nil if this is the first load.
+        ///   - previousX509CertificateChain: A swift-certificates representation of the certificate chain which was being used prior to this reload. This will be nil if this is the first load.
         ///   - previousPrivateKey: The private which was being used prior to this reload.  This will be nil if this is the first load.
+        ///   - previousX509PrivateKey: A swift-certificates representation of the private which was being used prior to this reload.  This will be nil if this is the first load.
         ///   - currentCertificateChain:  The certificate chain which has newly been loaded.
+        ///   - currentX509CertificateChain:  A swift-certificates representation of the certificate chain which has newly been loaded.
         ///   - currentPrivateKey: The private key which has newly been loaded.
+        ///   - currentX509PrivateKey: A swift-certificates representation of the private key which has newly been loaded.
         public init(
-            previousCertificateChain: [Certificate]?,
-            previousPrivateKey: Certificate.PrivateKey?,
-            currentCertificateChain: [Certificate],
-            currentPrivateKey: Certificate.PrivateKey
+            previousCertificateChain: [NIOSSLCertificateSource]?,
+            previousX509CertificateChain: [Certificate]?,
+            previousPrivateKey: NIOSSLPrivateKeySource?,
+            previousX509PrivateKey: Certificate.PrivateKey?,
+            currentCertificateChain: [NIOSSLCertificateSource],
+            currentX509CertificateChain: [Certificate],
+            currentPrivateKey: NIOSSLPrivateKeySource,
+            currentX509PrivateKey: Certificate.PrivateKey
         ) {
             self.previousCertificateChain = previousCertificateChain
+            self.previousX509CertificateChain = previousX509CertificateChain
             self.previousPrivateKey = previousPrivateKey
+            self.previousX509PrivateKey = previousX509PrivateKey
             self.currentCertificateChain = currentCertificateChain
+            self.currentX509CertificateChain = currentX509CertificateChain
             self.currentPrivateKey = currentPrivateKey
+            self.currentX509PrivateKey = currentX509PrivateKey
         }
     }
 
@@ -569,10 +605,14 @@ public struct TimedCertificateReloader: CertificateReloader {
         }
         self.onCertificateLoaded?(
             LoadedCertificateChainAndKeyPairDiff(
-                previousCertificateChain: oldPair?.x509Certificates,
-                previousPrivateKey: oldPair?.x509Key,
-                currentCertificateChain: certificates,
-                currentPrivateKey: key
+                previousCertificateChain: oldPair?.certificates,
+                previousX509CertificateChain: oldPair?.x509Certificates,
+                previousPrivateKey: oldPair?.privateKey,
+                previousX509PrivateKey: oldPair?.x509Key,
+                currentCertificateChain: newPair.certificates,
+                currentX509CertificateChain: newPair.x509Certificates,
+                currentPrivateKey: newPair.privateKey,
+                currentX509PrivateKey: newPair.x509Key
             )
         )
     }

--- a/Sources/NIOCertificateReloading/TimedCertificateReloader.swift
+++ b/Sources/NIOCertificateReloading/TimedCertificateReloader.swift
@@ -102,7 +102,7 @@ import Foundation
 /// The last-valid certificate-key pair (if any) will be returned as the ``sslContextConfigurationOverride``.
 ///
 /// Optionally, you may also observe any reloads by specifying the ``TimedCertificateReloader/Configuration/onCertificateLoaded`` parameter.
-/// This will notify you whenever a new certificate is loaded, and you will given an instance of ``TimedCertificateReloader/LoadedCertificateChainAndKeyPairDiff``.
+/// This will notify you whenever a new certificate is loaded, and you will be given an instance of ``TimedCertificateReloader/LoadedCertificateChainAndKeyPairDiff``.
 /// This struct contains the previous certificate and key, as well as the new ones. This is useful for example if you would like to log whenever a new certificate is loaded.
 /// ```swift
 /// let reloaderConfiguration = TimedCertificateReloader.Configuration(

--- a/Sources/NIOCertificateReloading/TimedCertificateReloader.swift
+++ b/Sources/NIOCertificateReloading/TimedCertificateReloader.swift
@@ -289,31 +289,31 @@ public struct TimedCertificateReloader: CertificateReloader {
     /// Provides information about a reload.
     public struct LoadedCertificateChainAndKeyPairDiff: Sendable {
         /// The certificate chain which was being used prior to this reload. This will be nil if this is the first load.
-        public var previousCertificates: [Certificate]?
+        public var previousCertificateChain: [Certificate]?
         /// The private which was being used prior to this reload.  This will be nil if this is the first load.
         public var previousPrivateKey: Certificate.PrivateKey?
         /// The certificate chain which has newly been loaded.
-        public var certificates: [Certificate]
+        public var currentCertificateChain: [Certificate]
         /// The private key which has newly been loaded.
-        public var privateKey: Certificate.PrivateKey
+        public var currentPrivateKey: Certificate.PrivateKey
 
         /// Create a new instance.
         /// - Note: You usually do not need to create instances of this object. However, it may be useful for writing unit tests.
         /// - Parameters:
-        ///   - previousCertificates: The certificate chain which was being used prior to this reload. This will be nil if this is the first load.
+        ///   - previousCertificateChain: The certificate chain which was being used prior to this reload. This will be nil if this is the first load.
         ///   - previousPrivateKey: The private which was being used prior to this reload.  This will be nil if this is the first load.
-        ///   - certificates:  The certificate chain which has newly been loaded.
-        ///   - privateKey: The private key which has newly been loaded.
+        ///   - currentCertificateChain:  The certificate chain which has newly been loaded.
+        ///   - currentPrivateKey: The private key which has newly been loaded.
         public init(
-            previousCertificates: [Certificate]?,
+            previousCertificateChain: [Certificate]?,
             previousPrivateKey: Certificate.PrivateKey?,
-            certificates: [Certificate],
-            privateKey: Certificate.PrivateKey
+            currentCertificateChain: [Certificate],
+            currentPrivateKey: Certificate.PrivateKey
         ) {
-            self.previousCertificates = previousCertificates
+            self.previousCertificateChain = previousCertificateChain
             self.previousPrivateKey = previousPrivateKey
-            self.certificates = certificates
-            self.privateKey = privateKey
+            self.currentCertificateChain = currentCertificateChain
+            self.currentPrivateKey = currentPrivateKey
         }
     }
 
@@ -569,10 +569,10 @@ public struct TimedCertificateReloader: CertificateReloader {
         }
         self.onCertificateLoaded?(
             LoadedCertificateChainAndKeyPairDiff(
-                previousCertificates: oldPair?.x509Certificates,
+                previousCertificateChain: oldPair?.x509Certificates,
                 previousPrivateKey: oldPair?.x509Key,
-                certificates: certificates,
-                privateKey: key
+                currentCertificateChain: certificates,
+                currentPrivateKey: key
             )
         )
     }

--- a/Tests/NIOCertificateReloadingTests/TimedCertificateReloaderTests.swift
+++ b/Tests/NIOCertificateReloadingTests/TimedCertificateReloaderTests.swift
@@ -306,16 +306,16 @@ final class TimedCertificateReloaderTests: XCTestCase {
                 // We reload every 50ms and slept 200. There should be 1 reload which has nil previous certs and at least 1 which does not.
                 let updates = updatesBox.withLockedValue { $0 }
                 XCTAssertGreaterThanOrEqual(updates.count, 2)
-                XCTAssertNil(updates.first?.previousCertificates)
+                XCTAssertNil(updates.first?.previousCertificateChain)
                 XCTAssertNil(updates.first?.previousPrivateKey)
                 for update in updates.dropFirst() {
-                    XCTAssertEqual(update.previousCertificates, update.certificates)
-                    XCTAssertEqual(update.previousPrivateKey, update.privateKey)
+                    XCTAssertEqual(update.previousCertificateChain, update.currentCertificateChain)
+                    XCTAssertEqual(update.previousPrivateKey, update.currentPrivateKey)
                 }
                 for updateInfo in updates {
-                    XCTAssertEqual(updateInfo.certificates.count, 1)
-                    XCTAssertEqual(updateInfo.certificates.first, Self.sampleCert)
-                    XCTAssertEqual(updateInfo.privateKey, .init(Self.samplePrivateKey1))
+                    XCTAssertEqual(updateInfo.currentCertificateChain.count, 1)
+                    XCTAssertEqual(updateInfo.currentCertificateChain.first, Self.sampleCert)
+                    XCTAssertEqual(updateInfo.currentPrivateKey, .init(Self.samplePrivateKey1))
                 }
 
                 // Now the overrides should be present.

--- a/Tests/NIOCertificateReloadingTests/TimedCertificateReloaderTests.swift
+++ b/Tests/NIOCertificateReloadingTests/TimedCertificateReloaderTests.swift
@@ -316,7 +316,10 @@ final class TimedCertificateReloaderTests: XCTestCase {
                 }
                 for updateInfo in updates {
                     XCTAssertEqual(updateInfo.currentCertificateChain.count, 1)
-                    XCTAssertEqual(updateInfo.currentCertificateChain, reloader.sslContextConfigurationOverride.certificateChain)
+                    XCTAssertEqual(
+                        updateInfo.currentCertificateChain,
+                        reloader.sslContextConfigurationOverride.certificateChain
+                    )
                     XCTAssertEqual(updateInfo.currentX509CertificateChain.first, Self.sampleCert)
                     XCTAssertEqual(updateInfo.currentPrivateKey, reloader.sslContextConfigurationOverride.privateKey)
                     XCTAssertEqual(updateInfo.currentX509PrivateKey, .init(Self.samplePrivateKey1))

--- a/Tests/NIOCertificateReloadingTests/TimedCertificateReloaderTests.swift
+++ b/Tests/NIOCertificateReloadingTests/TimedCertificateReloaderTests.swift
@@ -729,7 +729,7 @@ final class TimedCertificateReloaderTests: XCTestCase {
         onLoaded: (@Sendable (TimedCertificateReloader.LoadedCertificateChainAndKeyPairDiff) -> Void)? = nil,
         _ body: @escaping @Sendable (TimedCertificateReloader) async throws -> Void
     ) async throws {
-        var config = TimedCertificateReloader.Configuration(
+        let config = TimedCertificateReloader.Configuration(
             refreshInterval: .milliseconds(50),
             certificateSource: .init(
                 location: certificate.location,

--- a/Tests/NIOCertificateReloadingTests/TimedCertificateReloaderTests.swift
+++ b/Tests/NIOCertificateReloadingTests/TimedCertificateReloaderTests.swift
@@ -310,12 +310,16 @@ final class TimedCertificateReloaderTests: XCTestCase {
                 XCTAssertNil(updates.first?.previousPrivateKey)
                 for update in updates.dropFirst() {
                     XCTAssertEqual(update.previousCertificateChain, update.currentCertificateChain)
+                    XCTAssertEqual(update.previousX509CertificateChain, update.currentX509CertificateChain)
                     XCTAssertEqual(update.previousPrivateKey, update.currentPrivateKey)
+                    XCTAssertEqual(update.previousX509PrivateKey, update.currentX509PrivateKey)
                 }
                 for updateInfo in updates {
                     XCTAssertEqual(updateInfo.currentCertificateChain.count, 1)
-                    XCTAssertEqual(updateInfo.currentCertificateChain.first, Self.sampleCert)
-                    XCTAssertEqual(updateInfo.currentPrivateKey, .init(Self.samplePrivateKey1))
+                    XCTAssertEqual(updateInfo.currentCertificateChain, reloader.sslContextConfigurationOverride.certificateChain)
+                    XCTAssertEqual(updateInfo.currentX509CertificateChain.first, Self.sampleCert)
+                    XCTAssertEqual(updateInfo.currentPrivateKey, reloader.sslContextConfigurationOverride.privateKey)
+                    XCTAssertEqual(updateInfo.currentX509PrivateKey, .init(Self.samplePrivateKey1))
                 }
 
                 // Now the overrides should be present.


### PR DESCRIPTION
Add callback in TimedCertificateReloader to listen for reloads

### Motivation:

Adopter might want to know when a certificate was reloaded, e.g. to emit a log or metric

### Modifications:

- Add a new callback in the reloader which is called whenever a reload happens. The closure is passed a struct which tells us which cert and key were read, and whether or not theyre 'new'
- Change the initializer to take a config struct to make this more extensible going forward