### PR TITLE
Make a new variant of makeReloaderValidatingSources which takes a Configuration

### DIFF
--- a/Sources/NIOCertificateReloading/TimedCertificateReloader.swift
+++ b/Sources/NIOCertificateReloading/TimedCertificateReloader.swift
@@ -376,7 +376,7 @@ public struct TimedCertificateReloader: CertificateReloader {
             refreshInterval: Duration,
             certificateSource: CertificateSource,
             privateKeySource: PrivateKeySource,
-        _ configure: (inout Self) -> Void = { _ in }
+            _ configure: (inout Self) -> Void = { _ in }
         ) {
             self.refreshInterval = refreshInterval
             self.certificateSource = certificateSource
@@ -462,7 +462,6 @@ public struct TimedCertificateReloader: CertificateReloader {
     ///   - logger: An optional logger.
     /// - Returns: The newly created ``TimedCertificateReloader``.
     /// - Throws: If either the certificate or private key sources cannot be loaded, an error will be thrown.
-    @available(*, deprecated, renamed:  "makeReloaderValidatingSources(configuration:logger:)")
     public static func makeReloaderValidatingSources(
         refreshInterval: Duration,
         certificateSource: CertificateSource,


### PR DESCRIPTION
In #281 we added a Configuration object. Now it's possible to create a TimedCertificateReloader with a single configuration parameter. The makeReloaderValidatingSources function should be updated to also take this parameter