### PR TITLE
Build docs for NIOCertificateReloading

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,4 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [NIOExtras, NIOHTTPCompression, NIOSOCKS, NIOHTTPTypes, NIOHTTPTypesHTTP1, NIOHTTPTypesHTTP2, NIOResumableUpload, NIOHTTPResponsiveness]
+    - documentation_targets: [NIOExtras, NIOHTTPCompression, NIOSOCKS, NIOHTTPTypes, NIOHTTPTypesHTTP1, NIOHTTPTypesHTTP2, NIOResumableUpload, NIOHTTPResponsiveness, NIOCertificateReloading]


### PR DESCRIPTION
### Motivation:

Currently docs on SPI don't include NIOCertificateReloading.

### Modifications:

Added NIOCertificateReloading to the list of targets to build docs for.

### Result:

Docs on SPI.
