### PR TITLE
Make a few cleanups to the dripping download handler

### DIFF
--- a/Sources/NIOHTTPResponsiveness/HTTPDrippingDownloadHandler.swift
+++ b/Sources/NIOHTTPResponsiveness/HTTPDrippingDownloadHandler.swift
@@ -140,10 +140,10 @@ public final class HTTPDrippingDownloadHandler: ChannelDuplexHandler {
 
         // If the length isn't too big, let's include a content length header
         if case (let contentLength, false) = self.size.multipliedReportingOverflow(by: self.count) {
-            head.headerFields = HTTPFields(dictionaryLiteral: (.contentLength, "\(contentLength)"))
+            head.headerFields[.contentLength] = "\(contentLength)"
         }
 
-        context.writeAndFlush(self.wrapOutboundOut(.head(head)), promise: nil)
+        context.write(self.wrapOutboundOut(.head(head)), promise: nil)
         self.phase = .dripping(
             DrippingState(
                 chunksLeft: self.count,


### PR DESCRIPTION
Motivation

The dripping download handler should aim to be as efficient as possible.

Modifications

Avoid creating a second HTTPFields object when we are sending content-length in the response.
Avoid an extra flush on the response head.

Results

Better performance behaviour.
