### PR TITLE
Fix typo in `RPCErrors` case name

### DIFF
--- a/Sources/NIONFS3/NFSTypes+Containers.swift
+++ b/Sources/NIONFS3/NFSTypes+Containers.swift
@@ -531,7 +531,7 @@ extension ByteBuffer {
         }
 
         guard fragmentHeader.length >= 8 else {
-            throw RPCErrors.fragementHeaderLengthTooShort(fragmentHeader.length)
+            throw RPCErrors.fragmentHeaderLengthTooShort(fragmentHeader.length)
         }
 
         guard var body = self.readSlice(length: Int(fragmentHeader.length - 8)) else {

--- a/Sources/NIONFS3/RPCTypes.swift
+++ b/Sources/NIONFS3/RPCTypes.swift
@@ -180,7 +180,7 @@ public enum RPCRejectedReply: Hashable & Sendable {
 public enum RPCErrors: Error {
     case unknownType(UInt32)
     case tooLong(RPCFragmentHeader, xid: UInt32, messageType: UInt32)
-    case fragementHeaderLengthTooShort(UInt32)
+    case fragmentHeaderLengthTooShort(UInt32)
     case unknownVerifier(UInt32)
     case unknownVersion(UInt32)
     case invalidAuthFlavor(UInt32)


### PR DESCRIPTION
`fragementHeaderLengthTooShort` -> `fragmentHeaderLengthTooShort`

This pull request fixes a typo in the `RPCErrors` case name, correcting `fragementHeaderLengthTooShort` to `fragmentHeaderLengthTooShort`.
Both the enum case and the call site have been updated accordingly.