### PR TITLE
Drop Swift 6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,6 @@ jobs:
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.1
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ SwiftNIO Extras     | Minimum Swift Version
 `1.20.0 ..< 1.23.0` | 5.7.1
 `1.23.0 ..< 1.27.0` | 5.8
 `1.27.0 ..< 1.30.0` | 5.10
-`1.30.0 ...`        | 6.0
+`1.30.0 ..<`        | 6.0  **TODO:** Update version table
 
 On the [`nio-extras-0.1`](https://github.com/apple/swift-nio-extras/tree/nio-extras-0.1) branch, you can find the `swift-nio-extras` version for the SwiftNIO 1 family. It requires Swift 4.1 or better.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ SwiftNIO Extras     | Minimum Swift Version
 `1.20.0 ..< 1.23.0` | 5.7.1
 `1.23.0 ..< 1.27.0` | 5.8
 `1.27.0 ..< 1.30.0` | 5.10
-`1.30.0 ..<`        | 6.0  **TODO:** Update version table
+`1.30.0 ..< 1.34.0` | 6.0
+`1.34.0 ..<`        | 6.1
 
 On the [`nio-extras-0.1`](https://github.com/apple/swift-nio-extras/tree/nio-extras-0.1) branch, you can find the `swift-nio-extras` version for the SwiftNIO 1 family. It requires Swift 4.1 or better.
 


### PR DESCRIPTION
Motivation:

Swift 6.0 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 6.1
* Remove Swift 6.0 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
