### PR TITLE
Coalesce response head with body to avoid extra flush

### DIFF
--- a/Sources/NIOHTTPResponsiveness/HTTPDrippingDownloadHandler.swift
+++ b/Sources/NIOHTTPResponsiveness/HTTPDrippingDownloadHandler.swift
@@ -54,6 +54,7 @@ public final class HTTPDrippingDownloadHandler: ChannelDuplexHandler {
     private var pendingRead = false
     private var pendingWrite = false
     private var activelyWritingChunk = false
+    private var needsFlush = false
 
     /// Initializes an `HTTPDrippingDownloadHandler`.
     /// - Parameters:
@@ -144,6 +145,7 @@ public final class HTTPDrippingDownloadHandler: ChannelDuplexHandler {
         }
 
         context.write(self.wrapOutboundOut(.head(head)), promise: nil)
+        self.needsFlush = true
         self.phase = .dripping(
             DrippingState(
                 chunksLeft: self.count,
@@ -152,6 +154,12 @@ public final class HTTPDrippingDownloadHandler: ChannelDuplexHandler {
         )
 
         self.writeChunk(context: context)
+        // Ensure the head is flushed even if writeChunk didn't flush (e.g.
+        // zero-size chunks or channel not writable).
+        if self.needsFlush {
+            self.needsFlush = false
+            context.flush()
+        }
     }
 
     public func channelInactive(context: ChannelHandlerContext) {
@@ -184,6 +192,7 @@ public final class HTTPDrippingDownloadHandler: ChannelDuplexHandler {
         // If we've sent all chunks, send end and be done
         if drippingState.chunksLeft < 1 {
             self.phase = .done
+            self.needsFlush = false
             context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
             return
         }
@@ -208,6 +217,7 @@ public final class HTTPDrippingDownloadHandler: ChannelDuplexHandler {
             self.pendingWrite = true
             self.phase = .dripping(drippingState)
             if dataWritten {
+                self.needsFlush = false
                 context.flush()
             }
             return
@@ -217,11 +227,13 @@ public final class HTTPDrippingDownloadHandler: ChannelDuplexHandler {
         drippingState.chunksLeft -= 1
         if drippingState.chunksLeft == 0 {
             self.phase = .done
+            self.needsFlush = false
             context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
             return
         }
 
         if dataWritten {
+            self.needsFlush = false
             context.flush()
         }
 

--- a/Tests/NIOHTTPResponsivenessTests/HTTPDrippingDownloadHandlerTests.swift
+++ b/Tests/NIOHTTPResponsivenessTests/HTTPDrippingDownloadHandlerTests.swift
@@ -62,6 +62,30 @@ final class HTTPDrippingDownloadHandlerTests: XCTestCase {
         try dripTest(count: 1, size: 0)
     }
 
+    func testSmallDownloadDoesNotFlushHeadSeparately() throws {
+        let eventLoop = EmbeddedEventLoop()
+        let channel = EmbeddedChannel(loop: eventLoop)
+
+        // Track how many writes occur before the first flush.
+        let flushCounter = FlushCountingHandler()
+        try channel.pipeline.syncOperations.addHandler(flushCounter)
+        try channel.pipeline.syncOperations.addHandler(HTTPDrippingDownloadHandler(count: 1, size: 1000))
+
+        try channel.writeInbound(
+            HTTPRequestPart.head(HTTPRequest(method: .get, scheme: "http", authority: "whatever", path: nil))
+        )
+
+        // The response head, body, and end should all be written before the
+        // first flush — not head flushed separately then body+end.
+        XCTAssertEqual(
+            flushCounter.writesBeforeFirstFlush,
+            3,
+            "Expected head, body, and end to be written before the first flush"
+        )
+
+        let _ = try channel.finish()
+    }
+
     func dripTest(
         count: Int,
         size: Int = 1024,
@@ -134,4 +158,24 @@ final class HTTPDrippingDownloadHandlerTests: XCTestCase {
         #endif
     }
 
+}
+
+private final class FlushCountingHandler: ChannelOutboundHandler {
+    typealias OutboundIn = Any
+    typealias OutboundOut = Any
+
+    var writeCount = 0
+    var writesBeforeFirstFlush: Int?
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        self.writeCount += 1
+        context.write(data, promise: promise)
+    }
+
+    func flush(context: ChannelHandlerContext) {
+        if self.writesBeforeFirstFlush == nil {
+            self.writesBeforeFirstFlush = self.writeCount
+        }
+        context.flush()
+    }
 }


### PR DESCRIPTION
### Motivation

* `HTTPDrippingDownloadHandler` used `writeAndFlush` for the response head, causing it to be flushed separately from the body. This results in two flushes per response instead of one, which can produce extra packets on the wire for small downloads.

### Modifications

* Change `onResponseDelayCompleted` to use `context.write` instead of `context.writeAndFlush` for the response head, so it is coalesced with the body in the same flush.
* Add a `needsFlush` flag to ensure the head is still flushed promptly if `writeChunk` doesn't flush (e.g. zero-size chunks or channel not writable).
* Add `testSmallDownloadDoesNotFlushHeadSeparately` verifying that head, body, and end are all written before the first flush.

### Result

* For small single-chunk downloads, the response head and body are sent in a single flush instead of two.
