### PR TITLE
Return 0 for malformed q-values

### DIFF
--- a/Sources/NIOHTTPCompression/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTPCompression/HTTPResponseCompressor.swift
@@ -37,8 +37,17 @@ private func qValueFromHeader<S: StringProtocol>(_ text: S) -> Float {
         return 1
     }
 
-    // We have a Q value.
-    let qValue = Float(headerParts[1].split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)[1]) ?? 0
+    // We might have a Q value.
+    let qParts = headerParts[1].split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+
+    // A parameter without a value (e.g. "gzip;q") is malformed; treat as q=0.
+    guard qParts.count > 1 else { return 0 }
+
+    // Check the left hand side is a "q" or a "Q".
+    guard let qChar = qParts[0].utf8.first, qParts[0].utf8.count == 1 else { return 0 }
+    guard qChar == UInt8(ascii: "q") || qChar == UInt8(ascii: "Q") else { return 0 }
+
+    let qValue = Float(qParts[1]) ?? 0
     if qValue < 0 || qValue > 1 || qValue.isNaN {
         return 0
     }

--- a/Tests/NIOHTTPCompressionTests/HTTPRequestDecompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPRequestDecompressorTest.swift
@@ -203,9 +203,16 @@ class HTTPRequestDecompressorTest: XCTestCase {
             ("Content-Encoding", "gzip"),
             ("Content-Length", "\(compressed.readableBytes)"),
         ])
-        try channel.writeInbound(HTTPServerRequestPart.head(.init(
-            version: .init(major: 1, minor: 1), method: .POST, uri: "/", headers: headers
-        )))
+        try channel.writeInbound(
+            HTTPServerRequestPart.head(
+                .init(
+                    version: .init(major: 1, minor: 1),
+                    method: .POST,
+                    uri: "/",
+                    headers: headers
+                )
+            )
+        )
         XCTAssertThrowsError(try channel.writeInbound(HTTPServerRequestPart.body(compressed)))
     }
 
@@ -220,9 +227,16 @@ class HTTPRequestDecompressorTest: XCTestCase {
             ("Content-Encoding", "gzip"),
             ("Content-Length", "100000"),
         ])
-        try channel.writeInbound(HTTPServerRequestPart.head(.init(
-            version: .init(major: 1, minor: 1), method: .POST, uri: "/", headers: headers
-        )))
+        try channel.writeInbound(
+            HTTPServerRequestPart.head(
+                .init(
+                    version: .init(major: 1, minor: 1),
+                    method: .POST,
+                    uri: "/",
+                    headers: headers
+                )
+            )
+        )
         XCTAssertThrowsError(try channel.writeInbound(HTTPServerRequestPart.body(compressed)))
     }
 
@@ -237,9 +251,16 @@ class HTTPRequestDecompressorTest: XCTestCase {
             ("Content-Encoding", "gzip"),
             ("Content-Length", "100000"),
         ])
-        try channel.writeInbound(HTTPServerRequestPart.head(.init(
-            version: .init(major: 1, minor: 1), method: .POST, uri: "/", headers: headers
-        )))
+        try channel.writeInbound(
+            HTTPServerRequestPart.head(
+                .init(
+                    version: .init(major: 1, minor: 1),
+                    method: .POST,
+                    uri: "/",
+                    headers: headers
+                )
+            )
+        )
         XCTAssertThrowsError(try channel.writeInbound(HTTPServerRequestPart.body(compressed)))
     }
 
@@ -260,9 +281,16 @@ class HTTPRequestDecompressorTest: XCTestCase {
                 ("Content-Encoding", "gzip"),
                 ("Content-Length", "100000"),
             ])
-            try channel.writeInbound(HTTPServerRequestPart.head(.init(
-                version: .init(major: 1, minor: 1), method: .POST, uri: "/", headers: headers
-            )))
+            try channel.writeInbound(
+                HTTPServerRequestPart.head(
+                    .init(
+                        version: .init(major: 1, minor: 1),
+                        method: .POST,
+                        uri: "/",
+                        headers: headers
+                    )
+                )
+            )
             do {
                 try channel.writeInbound(HTTPServerRequestPart.body(compressed))
             } catch is NIOHTTPDecompression.DecompressionError {
@@ -277,7 +305,8 @@ class HTTPRequestDecompressorTest: XCTestCase {
         let configuredAllowance = requestCount * compressedSize * 10
         XCTAssertTrue(ratioLimitFired, "Ratio limit must fire — actual amplification far exceeds ratio(10)")
         XCTAssertLessThanOrEqual(
-            totalDecompressedBytes, configuredAllowance,
+            totalDecompressedBytes,
+            configuredAllowance,
             "Total decompressed bytes (\(totalDecompressedBytes)) must not exceed configured allowance (\(configuredAllowance))"
         )
     }

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseCompressorTest.swift
@@ -1012,6 +1012,58 @@ class HTTPResponseCompressorTest: XCTestCase {
 
         XCTAssertEqual(counter.withLockedValue { $0 }, 2)
     }
+
+    func testMalformedAcceptEncodingQValueNoEquals() throws {
+        try self.testMalformedAcceptEncodingQValueDoesNotCrash(qValue: "q")
+    }
+
+    func testMalformedAcceptEncodingQValueNoValue() throws {
+        try self.testMalformedAcceptEncodingQValueDoesNotCrash(qValue: "q=")
+    }
+
+    func testMalformedAcceptEncodingQValueNegative() throws {
+        try self.testMalformedAcceptEncodingQValueDoesNotCrash(qValue: "q=-1")
+    }
+
+    func testMalformedAcceptEncodingQValueNonNumeric() throws {
+        try self.testMalformedAcceptEncodingQValueDoesNotCrash(qValue: "q=bar")
+    }
+
+    func testMalformedAcceptEncodingQValueNotQ() throws {
+        try self.testMalformedAcceptEncodingQValueDoesNotCrash(qValue: "r=0.1")
+    }
+
+    func testMalformedAcceptEncodingQValueDoesNotCrash(qValue: String) throws {
+        let channel = try compressionChannel()
+        defer { XCTAssertNoThrow(try channel.finish()) }
+
+        try sendRequest(acceptEncoding: "gzip;\(qValue)", channel: channel)
+
+        let responseHead = HTTPResponseHead(version: .http1_1, status: .ok)
+        var body = channel.allocator.buffer(capacity: 4)
+        body.writeStaticString("test")
+        try writeOneChunk(head: responseHead, body: [body], channel: channel)
+
+        // The malformed token's q-value should be treated as 0 — no compression applied.
+        let clientChannel = clientParsingChannel()
+        defer { _ = try! clientChannel.finish() }
+        var requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/")
+        requestHead.headers.add(name: "host", value: "example.com")
+        clientChannel.write(HTTPClientRequestPart.head(requestHead), promise: nil)
+        clientChannel.write(HTTPClientRequestPart.end(nil), promise: nil)
+        while let b = try channel.readOutbound(as: ByteBuffer.self) {
+            try clientChannel.writeInbound(b)
+        }
+        var responseReceived: HTTPResponseHead? = nil
+        loop: while let part: HTTPClientResponsePart = try clientChannel.readInbound() {
+            if case .head(let h) = part {
+                responseReceived = h
+                break loop
+            }
+        }
+        XCTAssertNotNil(responseReceived)
+        XCTAssertEqual(responseReceived?.headers[canonicalForm: "content-encoding"], [])
+    }
 }
 
 extension EventLoopFuture {


### PR DESCRIPTION
Motivation:

Certain malformed q-values can trigger a crash because they don't validate that a string split results in the expected number of parts.

Modifications:

- validate that the number of split parts is as expected, return a q-value of zero otherwise (i.e. "not acceptable")

Result:

Safer code