### PR TITLE
Throw on invalid psuedoheaders when converting between http/2

### DIFF
--- a/Sources/NIOHTTPTypesHTTP2/HTTPTypeConversion.swift
+++ b/Sources/NIOHTTPTypesHTTP2/HTTPTypeConversion.swift
@@ -30,6 +30,7 @@ private enum HTTP2TypeConversionError: Error {
 
     case pseudoFieldNotFirst
     case pseudoFieldInTrailers
+    case unknownPseudoField
 }
 
 extension HPACKIndexing {
@@ -100,7 +101,7 @@ extension HPACKHeaders {
 }
 
 extension HTTPRequest {
-    init(_ hpack: HPACKHeaders) throws {
+    package init(_ hpack: HPACKHeaders) throws {
         var methodString: String? = nil
         var methodIndexable: HPACKIndexing = .indexable
         var schemeString: String? = nil
@@ -150,7 +151,7 @@ extension HTTPRequest {
                 protocolString = value
                 protocolIndexable = indexable
             default:
-                continue
+                throw HTTP2TypeConversionError.unknownPseudoField
             }
             i = hpack.index(after: i)
         }
@@ -194,7 +195,7 @@ extension HTTPRequest {
 }
 
 extension HTTPResponse {
-    init(_ hpack: HPACKHeaders) throws {
+    package init(_ hpack: HPACKHeaders) throws {
         var statusString: String? = nil
         var statusIndexable: HPACKIndexing = .indexable
 
@@ -212,7 +213,7 @@ extension HTTPResponse {
                 statusString = value
                 statusIndexable = indexable
             default:
-                continue
+                throw HTTP2TypeConversionError.unknownPseudoField
             }
             i = hpack.index(after: i)
         }

--- a/Sources/NIOHTTPTypesHTTP2/HTTPTypeConversion.swift
+++ b/Sources/NIOHTTPTypesHTTP2/HTTPTypeConversion.swift
@@ -15,7 +15,7 @@
 import HTTPTypes
 import NIOHPACK
 
-private enum HTTP2TypeConversionError: Error {
+package enum HTTP2TypeConversionError: Error, Equatable {
     case multipleMethod
     case multipleScheme
     case multipleAuthority

--- a/Tests/NIOHTTPTypesHTTP2Tests/NIOHTTPTypesHTTP2Tests.swift
+++ b/Tests/NIOHTTPTypesHTTP2Tests/NIOHTTPTypesHTTP2Tests.swift
@@ -190,6 +190,7 @@ final class NIOHTTPTypesHTTP2Tests: XCTestCase {
         try self.channel.writeInbound(HTTP2Frame.FramePayload(headers: malformedHeaders))
         XCTAssertNil(try self.channel.readInbound(as: HTTPRequestPart.self))
         XCTAssertEqual(errorRecorder.caughtErrors.count, 1)
+        XCTAssertEqual(errorRecorder.caughtErrors.first as? HTTP2TypeConversionError, .unknownPseudoField)
     }
 
     func testClientCodecFiresErrorOnUnrecognizedPseudoHeaderInResponse() throws {
@@ -210,6 +211,7 @@ final class NIOHTTPTypesHTTP2Tests: XCTestCase {
         try self.channel.writeInbound(HTTP2Frame.FramePayload(headers: malformedHeaders))
         XCTAssertNil(try self.channel.readInbound(as: HTTPResponsePart.self))
         XCTAssertEqual(errorRecorder.caughtErrors.count, 1)
+        XCTAssertEqual(errorRecorder.caughtErrors.first as? HTTP2TypeConversionError, .unknownPseudoField)
     }
 
     func testHTTPRequestInitThrowsOnUnrecognizedPseudoHeader() throws {
@@ -222,7 +224,9 @@ final class NIOHTTPTypesHTTP2Tests: XCTestCase {
             ":status": "200",  // invalid for requests
         ]
 
-        XCTAssertThrowsError(try HTTPRequest(headers))
+        XCTAssertThrowsError(try HTTPRequest(headers)) { error in
+            XCTAssertEqual(error as? HTTP2TypeConversionError, .unknownPseudoField)
+        }
     }
 
     func testHTTPResponseInitThrowsOnUnrecognizedPseudoHeader() throws {
@@ -233,6 +237,8 @@ final class NIOHTTPTypesHTTP2Tests: XCTestCase {
             ":method": "GET",  // invalid for responses.
         ]
 
-        XCTAssertThrowsError(try HTTPResponse(headers))
+        XCTAssertThrowsError(try HTTPResponse(headers)) { error in
+            XCTAssertEqual(error as? HTTP2TypeConversionError, .unknownPseudoField)
+        }
     }
 }

--- a/Tests/NIOHTTPTypesHTTP2Tests/NIOHTTPTypesHTTP2Tests.swift
+++ b/Tests/NIOHTTPTypesHTTP2Tests/NIOHTTPTypesHTTP2Tests.swift
@@ -32,6 +32,18 @@ private final class InboundRecorder<Frame>: ChannelInboundHandler {
     }
 }
 
+/// A handler that records errors fired down the pipeline via fireErrorCaught.
+private final class ErrorRecorder: ChannelInboundHandler {
+    // InboundIn is a placeholder; this handler only captures errors.
+    typealias InboundIn = ByteBuffer
+
+    var caughtErrors: [Error] = []
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        self.caughtErrors.append(error)
+    }
+}
+
 extension HTTPField.Name {
     static let xFoo = Self("X-Foo")!
 }
@@ -161,5 +173,66 @@ final class NIOHTTPTypesHTTP2Tests: XCTestCase {
         }
 
         XCTAssertTrue(try self.channel.finish().isClean)
+    }
+
+    func testServerCodecFiresErrorOnUnrecognizedPseudoHeaderInRequest() throws {
+        // A HEADERS frame containing ":status"  must be rejected for a
+        // request and should result in an error being thrown.
+        let malformedHeaders: HPACKHeaders = [
+            ":method": "GET",
+            ":scheme": "https",
+            ":path": "/",
+            ":status": "200",
+        ]
+
+        let errorRecorder = ErrorRecorder()
+        try self.channel.pipeline.syncOperations.addHandlers(HTTP2FramePayloadToHTTPServerCodec(), errorRecorder)
+        try self.channel.writeInbound(HTTP2Frame.FramePayload(headers: malformedHeaders))
+        XCTAssertNil(try self.channel.readInbound(as: HTTPRequestPart.self))
+        XCTAssertEqual(errorRecorder.caughtErrors.count, 1)
+    }
+
+    func testClientCodecFiresErrorOnUnrecognizedPseudoHeaderInResponse() throws {
+        // A HEADERS frame containing ":method"  must be rejected for a
+        // response and should result in an error being thrown.
+        let malformedHeaders: HPACKHeaders = [
+            ":status": "200",
+            ":method": "GET",
+        ]
+
+        let errorRecorder = ErrorRecorder()
+        try self.channel.pipeline.syncOperations.addHandlers(HTTP2FramePayloadToHTTPClientCodec(), errorRecorder)
+
+        // The client state machine requires a request to be sent before it will
+        // accept a response frame, so prime it with a request head.
+        try self.channel.writeOutbound(HTTPRequestPart.head(Self.request))
+
+        try self.channel.writeInbound(HTTP2Frame.FramePayload(headers: malformedHeaders))
+        XCTAssertNil(try self.channel.readInbound(as: HTTPResponsePart.self))
+        XCTAssertEqual(errorRecorder.caughtErrors.count, 1)
+    }
+
+    func testHTTPRequestInitThrowsOnUnrecognizedPseudoHeader() throws {
+        // `HTTP2TypeConversionError.unknownPseudoField` should be thrown if an invalid psuedo header
+        // is included in the response.
+        let headers: HPACKHeaders = [
+            ":method": "GET",
+            ":scheme": "https",
+            ":path": "/",
+            ":status": "200",  // invalid for requests
+        ]
+
+        XCTAssertThrowsError(try HTTPRequest(headers))
+    }
+
+    func testHTTPResponseInitThrowsOnUnrecognizedPseudoHeader() throws {
+        // `HTTP2TypeConversionError.unknownPseudoField` should be thrown if an invalid psuedo header
+        // is included in the response.
+        let headers: HPACKHeaders = [
+            ":status": "200",
+            ":method": "GET",  // invalid for responses.
+        ]
+
+        XCTAssertThrowsError(try HTTPResponse(headers))
     }
 }


### PR DESCRIPTION
Motivation:

The HTTPType to HTTP2 conversion functions can trip up on invalid psuedo header fields. Prior to this change they'll loop indefinitely, instead they should be rejected per RFC 9113 § 8.3.

Modifications:

- Throw on unrecognised psuedo header fields
- Add tests

Result:

- More spec compliant