### PR TITLE
Make the HTTP decompressors safe against synchronous channelRead re-entry

### DIFF
--- a/Sources/NIOHTTPCompression/HTTPDecompressor.swift
+++ b/Sources/NIOHTTPCompression/HTTPDecompressor.swift
@@ -93,83 +93,117 @@ private protocol HTTPHead: Equatable {
 extension HTTPRequestHead: HTTPHead {}
 extension HTTPResponseHead: HTTPHead {}
 
-private struct Decompressor<InboundHead: HTTPHead> {
+/// This class encapsulates the state of a single http message decompression
+private final class HTTPDecompressionDecoder: NIOSingleStepByteToMessageDecoder {
+    typealias InboundOut = ByteBuffer
+
+    private let allocator: ByteBufferAllocator
+    private var decompressor: NIOHTTPDecompression.Decompressor
+    /// The number of already consumed compressed bytes
+    private var compressedLength: Int
+    private var complete: Bool
+
+    init(limit: NIOHTTPDecompression.DecompressionLimit, allocator: ByteBufferAllocator) throws {
+        self.allocator = allocator
+        self.decompressor = NIOHTTPDecompression.Decompressor(limit: limit)
+        self.compressedLength = 0
+        self.complete = false
+        try self.decompressor.initializeDecoder()
+    }
+
+    deinit {
+        self.decompressor.deinitializeDecoder()
+    }
+
+    func decode(buffer: inout ByteBuffer) throws -> ByteBuffer? {
+        guard !self.complete, buffer.readableBytes > 0 else {
+            return nil
+        }
+
+        let compressedLength = self.compressedLength + buffer.readableBytes
+        var output = self.allocator.buffer(capacity: 16384)
+        let readableBytesBefore = buffer.readableBytes
+        let result = try self.decompressor.decompress(
+            part: &buffer,
+            buffer: &output,
+            compressedLength: compressedLength
+        )
+        self.compressedLength += readableBytesBefore - buffer.readableBytes
+        if result.complete {
+            self.complete = true
+        }
+        return output
+    }
+
+    func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> ByteBuffer? {
+        if let output = try self.decode(buffer: &buffer) {
+            return output
+        }
+        if !self.complete {
+            throw NIOHTTPDecompression.ExtraDecompressionError.truncatedData
+        }
+        return nil
+    }
+}
+
+private final class Decompressor<InboundHead: HTTPHead> {
     typealias Inbound = HTTPPart<InboundHead, ByteBuffer>
 
-    /// this struct encapsulates the state of a single http response decompression
-    private struct Compression {
-        /// the used algorithm
-        var algorithm: NIOHTTPDecompression.CompressionAlgorithm
-
-        /// the number of already consumed compressed bytes
-        var compressedLength: Int
-    }
-
-    private var compression: Compression? = nil
-    private var decompressor: NIOHTTPDecompression.Decompressor
-    private var decompressionComplete: Bool
+    private let limit: NIOHTTPDecompression.DecompressionLimit
+    private var processor: NIOSingleStepByteToMessageProcessor<HTTPDecompressionDecoder>?
 
     init(limit: NIOHTTPDecompression.DecompressionLimit) {
-        self.decompressor = NIOHTTPDecompression.Decompressor(limit: limit)
-        self.decompressionComplete = false
+        self.limit = limit
+        self.processor = nil
     }
 
-    mutating func channelRead(context: ChannelHandlerContext, part: Inbound) {
+    func channelRead(context: ChannelHandlerContext, part: Inbound) {
         switch part {
         case .head(let head):
             let contentType = head.headers[canonicalForm: "Content-Encoding"].first?.lowercased()
             let algorithm = NIOHTTPDecompression.CompressionAlgorithm(header: contentType)
 
             do {
-                if let algorithm = algorithm {
-                    self.compression = Compression(algorithm: algorithm, compressedLength: 0)
-                    try self.decompressor.initializeDecoder()
+                if algorithm != nil {
+                    let decoder = try HTTPDecompressionDecoder(
+                        limit: self.limit,
+                        allocator: context.channel.allocator
+                    )
+                    self.processor = NIOSingleStepByteToMessageProcessor(decoder)
                 }
 
                 context.fireChannelRead(NIOAny(part))
             } catch {
                 context.fireErrorCaught(error)
             }
-        case .body(var content):
-            guard var compression = self.compression else {
+        case .body(let buffer):
+            guard let processor = self.processor else {
                 context.fireChannelRead(NIOAny(part))
                 return
             }
 
             do {
-                compression.compressedLength += content.readableBytes
-                while content.readableBytes > 0 && !self.decompressionComplete {
-                    var buffer = context.channel.allocator.buffer(capacity: 16384)
-                    let result = try self.decompressor.decompress(
-                        part: &content,
-                        buffer: &buffer,
-                        compressedLength: compression.compressedLength
-                    )
-                    if result.complete {
-                        self.decompressionComplete = true
-                    }
-                    context.fireChannelRead(NIOAny(Inbound.body(buffer)))
+                try processor.process(buffer: buffer) { output in
+                    context.fireChannelRead(NIOAny(Inbound.body(output)))
                 }
 
-                // assign the changed local property back to the class state
-                self.compression = compression
-
-                if content.readableBytes > 0 {
+                // bytes left after the compressed body are invalid trailing data
+                if processor.unprocessedBytes > 0 {
                     context.fireErrorCaught(NIOHTTPDecompression.ExtraDecompressionError.invalidTrailingData)
                 }
             } catch {
                 context.fireErrorCaught(error)
             }
         case .end:
-            if self.compression != nil {
-                let wasDecompressionComplete = self.decompressionComplete
+            if let processor = self.processor {
+                self.processor = nil
 
-                self.decompressor.deinitializeDecoder()
-                self.compression = nil
-                self.decompressionComplete = false
-
-                if !wasDecompressionComplete {
-                    context.fireErrorCaught(NIOHTTPDecompression.ExtraDecompressionError.truncatedData)
+                do {
+                    try processor.finishProcessing(seenEOF: true) { output in
+                        context.fireChannelRead(NIOAny(Inbound.body(output)))
+                    }
+                } catch {
+                    context.fireErrorCaught(error)
                 }
             }
             context.fireChannelRead(NIOAny(part))

--- a/Tests/NIOHTTPCompressionTests/HTTPRequestDecompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPRequestDecompressorTest.swift
@@ -304,6 +304,101 @@ class HTTPRequestDecompressorTest: XCTestCase {
         XCTAssertThrowsError(try channel.writeInbound(HTTPServerRequestPart.end(nil)))
     }
 
+    func testReentrantChannelReadDuringForwardIsSafe() throws {
+        let channel = EmbeddedChannel()
+        let recorder = Recorder<HTTPServerRequestPart>()
+
+        let reinjected = HTTPServerRequestPart.head(.init(version: .http1_1, method: .GET, uri: "/"))
+        try channel.pipeline.syncOperations.addHandler(NIOHTTPRequestDecompressor(limit: .none))
+        try channel.pipeline.syncOperations.addHandler(
+            ReinjectOnce<HTTPServerRequestPart>(on: .read) { reinjected }
+        )
+        try channel.pipeline.syncOperations.addHandler(recorder)
+
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/")
+        head.headers.add(name: "Content-Encoding", value: "gzip")
+
+        XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.head(head)))
+        XCTAssertEqual(recorder.reads.count, 2)
+        XCTAssertNoThrow(try channel.finish())
+    }
+
+    func testReentrantChannelReadDuringErrorCaughtIsSafe() throws {
+        let channel = EmbeddedChannel()
+        let recorder = Recorder<HTTPServerRequestPart>()
+
+        let reinjected = HTTPServerRequestPart.head(.init(version: .http1_1, method: .GET, uri: "/"))
+        try channel.pipeline.syncOperations.addHandler(NIOHTTPRequestDecompressor(limit: .none))
+        try channel.pipeline.syncOperations.addHandler(
+            ReinjectOnce<HTTPServerRequestPart>(on: .error) { reinjected }
+        )
+        try channel.pipeline.syncOperations.addHandler(recorder)
+
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/")
+        head.headers.add(name: "Content-Encoding", value: "deflate")
+        XCTAssertNoThrow(try channel.writeInbound(HTTPServerRequestPart.head(head)))
+
+        // invalid deflate payload
+        var badBody = channel.allocator.buffer(capacity: 4)
+        badBody.writeBytes([0xff, 0xff, 0xff, 0xff])
+        _ = try? channel.writeInbound(HTTPServerRequestPart.body(badBody))
+
+        XCTAssertFalse(recorder.errors.isEmpty)
+        XCTAssertTrue(recorder.reads.contains { if case .head = $0 { return true } else { return false } })
+        _ = try? channel.finish()
+    }
+
+    private final class Recorder<Part>: ChannelInboundHandler {
+        typealias InboundIn = Part
+
+        private(set) var reads: [Part] = []
+        private(set) var errors: [Error] = []
+
+        func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+            self.reads.append(Self.unwrapInboundIn(data))
+            context.fireChannelRead(data)
+        }
+
+        func errorCaught(context: ChannelHandlerContext, error: Error) {
+            self.errors.append(error)
+            context.fireErrorCaught(error)
+        }
+    }
+
+    private final class ReinjectOnce<Part: Sendable>: ChannelInboundHandler {
+        typealias InboundIn = Part
+
+        enum Trigger {
+            case read
+            case error
+        }
+
+        private let trigger: Trigger
+        private let reinject: () -> Part
+        private var fired = false
+
+        init(on trigger: Trigger, reinject: @escaping () -> Part) {
+            self.trigger = trigger
+            self.reinject = reinject
+        }
+
+        func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+            if self.trigger == .read, !self.fired {
+                self.fired = true
+                context.channel.pipeline.fireChannelRead(self.reinject())
+            }
+            context.fireChannelRead(data)
+        }
+
+        func errorCaught(context: ChannelHandlerContext, error: Error) {
+            if self.trigger == .error, !self.fired {
+                self.fired = true
+                context.channel.pipeline.fireChannelRead(self.reinject())
+            }
+            context.fireErrorCaught(error)
+        }
+    }
+
     private func compress(_ body: ByteBuffer, _ algorithm: String) -> ByteBuffer {
         var stream = cnioextras_z_stream()
 

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest.swift
@@ -359,6 +359,101 @@ class HTTPResponseDecompressorTest: XCTestCase {
         XCTAssertNoThrow(try channel.writeInbound(HTTPClientResponsePart.body(compressed)))
         XCTAssertThrowsError(try channel.writeInbound(HTTPClientResponsePart.end(nil)))
     }
+    
+    func testReentrantChannelReadDuringForwardIsSafe() throws {
+        let channel = EmbeddedChannel()
+        let recorder = Recorder<HTTPClientResponsePart>()
+
+        let reinjected = HTTPClientResponsePart.head(.init(version: .http1_1, status: .ok))
+        try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .none))
+        try channel.pipeline.syncOperations.addHandler(
+            ReinjectOnce<HTTPClientResponsePart>(on: .read) { reinjected }
+        )
+        try channel.pipeline.syncOperations.addHandler(recorder)
+
+        var head = HTTPResponseHead(version: .http1_1, status: .ok)
+        head.headers.add(name: "Content-Encoding", value: "gzip")
+        
+        XCTAssertNoThrow(try channel.writeInbound(HTTPClientResponsePart.head(head)))
+        XCTAssertEqual(recorder.reads.count, 2)
+        XCTAssertNoThrow(try channel.finish())
+    }
+
+    func testReentrantChannelReadDuringErrorCaughtIsSafe() throws {
+        let channel = EmbeddedChannel()
+        let recorder = Recorder<HTTPClientResponsePart>()
+
+        let reinjected = HTTPClientResponsePart.head(.init(version: .http1_1, status: .ok))
+        try channel.pipeline.syncOperations.addHandler(NIOHTTPResponseDecompressor(limit: .none))
+        try channel.pipeline.syncOperations.addHandler(
+            ReinjectOnce<HTTPClientResponsePart>(on: .error) { reinjected }
+        )
+        try channel.pipeline.syncOperations.addHandler(recorder)
+
+        var head = HTTPResponseHead(version: .http1_1, status: .ok)
+        head.headers.add(name: "Content-Encoding", value: "deflate")
+        XCTAssertNoThrow(try channel.writeInbound(HTTPClientResponsePart.head(head)))
+
+        // invalid deflate payload
+        var badBody = channel.allocator.buffer(capacity: 4)
+        badBody.writeBytes([0xff, 0xff, 0xff, 0xff])
+        _ = try? channel.writeInbound(HTTPClientResponsePart.body(badBody))
+
+        XCTAssertFalse(recorder.errors.isEmpty)
+        XCTAssertTrue(recorder.reads.contains { if case .head = $0 { return true } else { return false } })
+        _ = try? channel.finish()
+    }
+
+    private final class Recorder<Part>: ChannelInboundHandler {
+        typealias InboundIn = Part
+
+        private(set) var reads: [Part] = []
+        private(set) var errors: [Error] = []
+
+        func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+            self.reads.append(Self.unwrapInboundIn(data))
+            context.fireChannelRead(data)
+        }
+
+        func errorCaught(context: ChannelHandlerContext, error: Error) {
+            self.errors.append(error)
+            context.fireErrorCaught(error)
+        }
+    }
+
+    private final class ReinjectOnce<Part: Sendable>: ChannelInboundHandler {
+        typealias InboundIn = Part
+
+        enum Trigger {
+            case read
+            case error
+        }
+
+        private let trigger: Trigger
+        private let reinject: () -> Part
+        private var fired = false
+
+        init(on trigger: Trigger, reinject: @escaping () -> Part) {
+            self.trigger = trigger
+            self.reinject = reinject
+        }
+
+        func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+            if self.trigger == .read, !self.fired {
+                self.fired = true
+                context.channel.pipeline.fireChannelRead(self.reinject())
+            }
+            context.fireChannelRead(data)
+        }
+
+        func errorCaught(context: ChannelHandlerContext, error: Error) {
+            if self.trigger == .error, !self.fired {
+                self.fired = true
+                context.channel.pipeline.fireChannelRead(self.reinject())
+            }
+            context.fireErrorCaught(error)
+        }
+    }
 
     private func compress(_ body: ByteBuffer, _ algorithm: String) -> ByteBuffer {
         var stream = cnioextras_z_stream()

--- a/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest.swift
+++ b/Tests/NIOHTTPCompressionTests/HTTPResponseDecompressorTest.swift
@@ -359,7 +359,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
         XCTAssertNoThrow(try channel.writeInbound(HTTPClientResponsePart.body(compressed)))
         XCTAssertThrowsError(try channel.writeInbound(HTTPClientResponsePart.end(nil)))
     }
-    
+
     func testReentrantChannelReadDuringForwardIsSafe() throws {
         let channel = EmbeddedChannel()
         let recorder = Recorder<HTTPClientResponsePart>()
@@ -373,7 +373,7 @@ class HTTPResponseDecompressorTest: XCTestCase {
 
         var head = HTTPResponseHead(version: .http1_1, status: .ok)
         head.headers.add(name: "Content-Encoding", value: "gzip")
-        
+
         XCTAssertNoThrow(try channel.writeInbound(HTTPClientResponsePart.head(head)))
         XCTAssertEqual(recorder.reads.count, 2)
         XCTAssertNoThrow(try channel.finish())


### PR DESCRIPTION
### Motivation:

`NIOHTTPRequestDecompressor` / `NIOHTTPResponseDecompressor` keep their state in a
stored `var decompressor` (a `struct`) and forwarded downstream (`fireChannelRead` /
`fireErrorCaught`) from inside that struct's `mutating` `channelRead`, i.e. while an
exclusive (modify) access to the stored property was still open. If firing downstream
synchronously re-enters the handler's `channelRead`, a second exclusive access is
opened and the program traps with `Fatal access conflict detected` (SIGABRT).

This reproduces in production with AsyncHTTPClient over HTTP/2 and
`decompression = .enabled`: a compressed response is mid-decompress when a
decompression error closes the stream, and the buffered read re-delivered on the
stream-close path re-enters `channelRead` on the same decompressor.

### Modifications:

- The body decompression is now expressed as a `NIOSingleStepByteToMessageDecoder`,
  driven by a `NIOSingleStepByteToMessageProcessor`. The handler pulls one decompressed
  buffer at a time and forwards it only after `decode` has returned, so the decoder
  relinquishes its exclusive access before anything is fired downstream.
- The shared driver is now a `class`, so the head/end forwarding paths are re-entrancy
  safe for the same reason.
- The zlib stream is torn down in the decoder's `deinit`, which additionally fixes a
  leak when a message ends without a final `.end`.
- No public API changes.

### Result:

Synchronous re-entry of `channelRead` no longer traps. Adds regression tests covering
the forward and error re-entry paths on both decompressors; all existing decompression
tests (limits, trailing data, truncation, multi-message reuse) continue to pass.

Fixes #314