### PR TITLE
Fix HTTPResumableUploadHandler dropping responses after the first request on a connection

### DIFF
--- a/Sources/NIOResumableUpload/HTTPResumableUploadHandler.swift
+++ b/Sources/NIOResumableUpload/HTTPResumableUploadHandler.swift
@@ -70,6 +70,7 @@ public final class HTTPResumableUploadHandler: ChannelDuplexHandler {
         if let existingUpload = self.upload {
             existingUpload.end(handler: self, error: nil)
         }
+        self.context = context
         let upload = self.createUpload()
         upload.scheduleOnEventLoop(self.eventLoop)
         upload.attachUploadHandler(self.sendableView, channel: context.channel)

--- a/Tests/NIOResumableUploadTests/NIOResumableUploadTests.swift
+++ b/Tests/NIOResumableUploadTests/NIOResumableUploadTests.swift
@@ -84,6 +84,125 @@ final class NIOResumableUploadTests: XCTestCase {
         XCTAssertTrue(try channel.finish().isClean)
     }
 
+    func testNonUploadKeepAlive() throws {
+        let channel = EmbeddedChannel()
+        let recorder = InboundRecorder<HTTPRequestPart, HTTPResponsePart>()
+
+        let context = HTTPResumableUploadContext(origin: "https://example.com")
+        try channel.pipeline.syncOperations.addHandler(
+            HTTPResumableUploadHandler(context: context, handlers: [recorder])
+        )
+
+        let request = HTTPRequest(method: .get, scheme: "https", authority: "example.com", path: "/")
+        try channel.writeInbound(HTTPRequestPart.head(request))
+        try channel.writeInbound(HTTPRequestPart.end(nil))
+
+        XCTAssertEqual(recorder.receivedFrames.count, 2)
+
+        recorder.write(HTTPResponsePart.head(HTTPResponse(status: .ok)))
+        recorder.write(HTTPResponsePart.end(nil))
+
+        let responsePart = try channel.readOutbound(as: HTTPResponsePart.self)
+        guard case .head(let response) = responsePart else {
+            XCTFail("Part is not response headers")
+            return
+        }
+        XCTAssertEqual(response.status, .ok)
+        guard let responsePart = try channel.readOutbound(as: HTTPResponsePart.self), case .end = responsePart else {
+            XCTFail("Part is not response end")
+            return
+        }
+
+        // A second request on the same channel, as with HTTP/1.1 keep-alive.
+        try channel.writeInbound(HTTPRequestPart.head(request))
+        try channel.writeInbound(HTTPRequestPart.end(nil))
+
+        XCTAssertEqual(recorder.receivedFrames.count, 4)
+
+        recorder.write(HTTPResponsePart.head(HTTPResponse(status: .ok)))
+        recorder.write(HTTPResponsePart.end(nil))
+
+        let secondResponsePart = try channel.readOutbound(as: HTTPResponsePart.self)
+        guard case .head(let secondResponse) = secondResponsePart else {
+            XCTFail("Part is not response headers")
+            return
+        }
+        XCTAssertEqual(secondResponse.status, .ok)
+        guard let secondResponsePart = try channel.readOutbound(as: HTTPResponsePart.self),
+            case .end = secondResponsePart
+        else {
+            XCTFail("Part is not response end")
+            return
+        }
+        XCTAssertTrue(try channel.finish().isClean)
+    }
+
+    func testResumableUploadKeepAlive() throws {
+        let channel = EmbeddedChannel()
+        let recorder = InboundRecorder<HTTPRequestPart, HTTPResponsePart>()
+
+        let context = HTTPResumableUploadContext(origin: "https://example.com")
+        try channel.pipeline.syncOperations.addHandler(
+            HTTPResumableUploadHandler(context: context, handlers: [recorder])
+        )
+
+        var request = HTTPRequest(method: .post, scheme: "https", authority: "example.com", path: "/")
+        request.headerFields[.uploadDraftInteropVersion] = "6"
+        request.headerFields[.uploadComplete] = "?1"
+        request.headerFields[.contentLength] = "5"
+        request.headerFields[.uploadLength] = "5"
+        try channel.writeInbound(HTTPRequestPart.head(request))
+        try channel.writeInbound(HTTPRequestPart.body(ByteBuffer(string: "Hello")))
+        try channel.writeInbound(HTTPRequestPart.end(nil))
+
+        XCTAssertEqual(recorder.receivedFrames.count, 3)
+
+        let informationalResponsePart = try channel.readOutbound(as: HTTPResponsePart.self)
+        guard case .head(let informationalResponse) = informationalResponsePart else {
+            XCTFail("Part is not response headers")
+            return
+        }
+        XCTAssertEqual(informationalResponse.status.code, 104)
+
+        recorder.write(HTTPResponsePart.head(HTTPResponse(status: .created)))
+        recorder.write(HTTPResponsePart.end(nil))
+
+        let responsePart = try channel.readOutbound(as: HTTPResponsePart.self)
+        guard case .head(let response) = responsePart else {
+            XCTFail("Part is not response headers")
+            return
+        }
+        XCTAssertEqual(response.status, .created)
+        guard let responsePart = try channel.readOutbound(as: HTTPResponsePart.self), case .end = responsePart else {
+            XCTFail("Part is not response end")
+            return
+        }
+
+        // A second request on the same channel, as with HTTP/1.1 keep-alive.
+        let secondRequest = HTTPRequest(method: .get, scheme: "https", authority: "example.com", path: "/")
+        try channel.writeInbound(HTTPRequestPart.head(secondRequest))
+        try channel.writeInbound(HTTPRequestPart.end(nil))
+
+        XCTAssertEqual(recorder.receivedFrames.count, 5)
+
+        recorder.write(HTTPResponsePart.head(HTTPResponse(status: .ok)))
+        recorder.write(HTTPResponsePart.end(nil))
+
+        let secondResponsePart = try channel.readOutbound(as: HTTPResponsePart.self)
+        guard case .head(let secondResponse) = secondResponsePart else {
+            XCTFail("Part is not response headers")
+            return
+        }
+        XCTAssertEqual(secondResponse.status, .ok)
+        guard let secondResponsePart = try channel.readOutbound(as: HTTPResponsePart.self),
+            case .end = secondResponsePart
+        else {
+            XCTFail("Part is not response end")
+            return
+        }
+        XCTAssertTrue(try channel.finish().isClean)
+    }
+
     func testOptions() throws {
         let channel = EmbeddedChannel()
         let recorder = InboundRecorder<HTTPRequestPart, HTTPResponsePart>()


### PR DESCRIPTION
Fix `HTTPResumableUploadHandler` silently dropping all responses after the first request on a connection.

### Motivation:

`HTTPResumableUploadHandler` forwards all outbound operations through its stored `ChannelHandlerContext`, which is set only in `handlerAdded` and cleared by `detach()` whenever an upload releases the handler. When a second request arrives on the same channel — the normal case for HTTP/1.1 with keep-alive — `channelRead` calls `resetUpload`, which ends the previous upload. That synchronously detaches the handler and clears its context, and nothing restores it before the new upload is attached. Every response write for the second and subsequent requests then hits `self.context?.write(...)` as a no-op: the response is silently dropped, write promises never complete, and `read()` forwarding to the parent channel stops, so the client hangs until it times out.

The existing tests never caught this because each test sends one request per `EmbeddedChannel`; resumption is only exercised across separate channels, and per-stream channels (HTTP/2) recreate the handler per request, which also masks the bug.

### Modifications:

- Restore `self.context` in `resetUpload(context:)` after ending the previous upload.
- Add `testNonUploadKeepAlive` and `testResumableUploadKeepAlive`, which send a second request on the same `EmbeddedChannel` for pass-through traffic and after a completed upload creation respectively. Both fail without the fix.

### Result:

Connections handled by `HTTPResumableUploadHandler` can serve more than one request: responses to the second and subsequent requests on a keep-alive connection are delivered instead of being silently dropped.

Fixes #318