### PR TITLE
Make TimedCertificateReloader reload asynchronously

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -271,6 +271,7 @@ var targets: [PackageDescription.Target] = [
         name: "NIOCertificateReloading",
         dependencies: [
             .product(name: "NIOCore", package: "swift-nio"),
+            .product(name: "NIOPosix", package: "swift-nio"),
             .product(name: "NIOSSL", package: "swift-nio-ssl"),
             .product(name: "X509", package: "swift-certificates"),
             .product(name: "SwiftASN1", package: "swift-asn1"),

--- a/Sources/NIOCertificateReloading/TimedCertificateReloader.swift
+++ b/Sources/NIOCertificateReloading/TimedCertificateReloader.swift
@@ -36,7 +36,7 @@ import Foundation
 /// key via ``init(refreshInterval:certificateSource:privateKeySource:logger:)``.
 /// Simply creating a timed reloader won't validate that the sources provide valid certificate and private key pairs. If you want this to be
 /// validated at creation time, you may instead use
-/// ``makeReloaderValidatingSources(refreshInterval:certificateSource:privateKeySource:logger:)``.
+/// ``makeReloaderValidatingSources(refreshInterval:certificateSource:privateKeySource:logger:)-3c5se``.
 ///
 /// You may then set the timed reloader on your ``NIOSSL/TLSConfiguration`` using
 /// ``NIOSSL/TLSConfiguration/setCertificateReloader(_:)``:
@@ -76,7 +76,7 @@ import Foundation
 /// ```
 ///
 /// In both cases, make sure you've either called ``run()`` or created the ``TimedCertificateReloader`` using
-/// ``makeReloaderValidatingSources(refreshInterval:certificateSource:privateKeySource:logger:)``
+/// ``makeReloaderValidatingSources(refreshInterval:certificateSource:privateKeySource:logger:)-3c5se``
 /// _before_ creating the ``NIOSSL/TLSConfiguration``, as otherwise the validation will fail.
 ///
 /// Once the reloader is running, you can manually access its ``sslContextConfigurationOverride`` property to get a
@@ -413,8 +413,8 @@ public struct TimedCertificateReloader: CertificateReloader {
     /// Its certificate and private key will be kept up-to-date via the reload mechanism the ``TimedCertificateReloader``
     /// implementation provides.
     /// - Note: If no reload attempt has yet been tried (either by creating the reloader with
-    /// ``makeReloaderValidatingSources(refreshInterval:certificateSource:privateKeySource:logger:)``,
-    /// manually calling ``reload()``, or by calling ``run()``), `NIOSSLContextConfigurationOverride/noChanges`
+    /// ``makeReloaderValidatingSources(refreshInterval:certificateSource:privateKeySource:logger:)-3c5se``,
+    /// manually calling ``reload()-7zipa``, or by calling ``run()``), `NIOSSLContextConfigurationOverride/noChanges`
     /// will be returned.
     public var sslContextConfigurationOverride: NIOSSLContextConfigurationOverride {
         get {
@@ -431,7 +431,7 @@ public struct TimedCertificateReloader: CertificateReloader {
     /// Initialize a new ``TimedCertificateReloader``.
     /// - Important: ``TimedCertificateReloader/sslContextConfigurationOverride`` will return
     /// `NIOSSLContextConfigurationOverride/noChanges` until ``TimedCertificateReloader/run()`` or
-    /// ``TimedCertificateReloader/reload()`` are called.
+    /// ``TimedCertificateReloader/reload()-7zipa`` are called.
     /// - Parameters:
     ///   - refreshInterval: The interval at which attempts to update the certificate and private key should be made.
     ///   - certificateSource: A ``TimedCertificateReloader/CertificateSource``.
@@ -456,7 +456,7 @@ public struct TimedCertificateReloader: CertificateReloader {
     /// Initialize a new ``TimedCertificateReloader``.
     /// - Important: ``TimedCertificateReloader/sslContextConfigurationOverride`` will return
     /// `NIOSSLContextConfigurationOverride/noChanges` until ``TimedCertificateReloader/run()`` or
-    /// ``TimedCertificateReloader/reload()`` are called.
+    /// ``TimedCertificateReloader/reload()-7zipa`` are called.
     /// - Parameter configuration: Configuration for this reloader.
     public init(
         configuration: Configuration

--- a/Sources/NIOCertificateReloading/TimedCertificateReloader.swift
+++ b/Sources/NIOCertificateReloading/TimedCertificateReloader.swift
@@ -15,6 +15,7 @@
 import AsyncAlgorithms
 import Logging
 import NIOConcurrencyHelpers
+import NIOPosix
 import NIOSSL
 import ServiceLifecycle
 import SwiftASN1
@@ -54,7 +55,7 @@ import Foundation
 /// ```
 ///
 /// Finally, you must call ``run()`` on the reloader for it to start observing changes.
-/// If you want to trigger a manual reload at any point, you may call ``reload()``.
+/// If you want to trigger a manual reload at any point, you may call `try await reloader.reload()`.
 ///
 /// If you're creating a server configuration, you can instead opt to use
 /// ``NIOSSL/TLSConfiguration/makeServerConfiguration(certificateReloader:)``, which will set the initial
@@ -481,6 +482,7 @@ public struct TimedCertificateReloader: CertificateReloader {
     ///   - logger: An optional logger.
     /// - Returns: The newly created ``TimedCertificateReloader``.
     /// - Throws: If either the certificate or private key sources cannot be loaded, an error will be thrown.
+    @available(*, deprecated, message: "This can block the calling thread. Use the async overload instead.")
     public static func makeReloaderValidatingSources(
         refreshInterval: Duration,
         certificateSource: CertificateSource,
@@ -494,7 +496,35 @@ public struct TimedCertificateReloader: CertificateReloader {
         ) {
             $0.logger = logger
         }
-        return try makeReloaderValidatingSources(configuration: configuration)
+        return try self.makeReloaderValidatingSourcesSynchronously(configuration: configuration)
+    }
+
+    /// Initialize a new ``TimedCertificateReloader``, and asynchronously attempt to reload the certificate and private
+    /// key pair from the given sources. If the reload fails (because e.g. the paths aren't valid), this method will throw.
+    /// - Important: If this method does not throw, it is guaranteed that
+    /// ``TimedCertificateReloader/sslContextConfigurationOverride`` will contain the configured certificate and
+    /// private key pair, even before the first reload is triggered or ``TimedCertificateReloader/run()`` is called.
+    /// - Parameters:
+    ///   - refreshInterval: The interval at which attempts to update the certificate and private key should be made.
+    ///   - certificateSource: A ``TimedCertificateReloader/CertificateSource``.
+    ///   - privateKeySource: A ``TimedCertificateReloader/PrivateKeySource``.
+    ///   - logger: An optional logger.
+    /// - Returns: The newly created ``TimedCertificateReloader``.
+    /// - Throws: If either the certificate or private key sources cannot be loaded, an error will be thrown.
+    public static func makeReloaderValidatingSources(
+        refreshInterval: Duration,
+        certificateSource: CertificateSource,
+        privateKeySource: PrivateKeySource,
+        logger: Logger? = nil
+    ) async throws -> Self {
+        let configuration = Configuration(
+            refreshInterval: refreshInterval,
+            certificateSource: certificateSource,
+            privateKeySource: privateKeySource
+        ) {
+            $0.logger = logger
+        }
+        return try await self.makeReloaderValidatingSources(configuration: configuration)
     }
 
     /// Initialize a new ``TimedCertificateReloader``, and attempt to reload the certificate and private key pair from the given
@@ -505,11 +535,34 @@ public struct TimedCertificateReloader: CertificateReloader {
     /// - Parameter configuration: Configuration for the ``TimedCertificateReloader``.
     /// - Returns: The newly created ``TimedCertificateReloader``.
     /// - Throws: If either the certificate or private key sources cannot be loaded, an error will be thrown.
+    @available(*, deprecated, message: "This can block the calling thread. Use the async overload instead.")
     public static func makeReloaderValidatingSources(
         configuration: Configuration
     ) throws -> Self {
+        try self.makeReloaderValidatingSourcesSynchronously(configuration: configuration)
+    }
+
+    /// Initialize a new ``TimedCertificateReloader``, and asynchronously attempt to reload the certificate and private
+    /// key pair from the given sources. If the reload fails (because e.g. the paths aren't valid), this method will throw.
+    /// - Important: If this method does not throw, it is guaranteed that
+    /// ``TimedCertificateReloader/sslContextConfigurationOverride`` will contain the configured certificate and
+    /// private key pair, even before the first reload is triggered or ``TimedCertificateReloader/run()`` is called.
+    /// - Parameter configuration: Configuration for the ``TimedCertificateReloader``.
+    /// - Returns: The newly created ``TimedCertificateReloader``.
+    /// - Throws: If either the certificate or private key sources cannot be loaded, an error will be thrown.
+    public static func makeReloaderValidatingSources(
+        configuration: Configuration
+    ) async throws -> Self {
         let reloader = Self.init(configuration: configuration)
-        try reloader.reload()
+        try await reloader.reload()
+        return reloader
+    }
+
+    private static func makeReloaderValidatingSourcesSynchronously(
+        configuration: Configuration
+    ) throws -> Self {
+        let reloader = Self.init(configuration: configuration)
+        try reloader.reloadSynchronously()
         return reloader
     }
 
@@ -519,7 +572,9 @@ public struct TimedCertificateReloader: CertificateReloader {
     public func run() async throws {
         for try await _ in AsyncTimerSequence.repeating(every: self.refreshInterval).cancelOnGracefulShutdown() {
             do {
-                try self.reload()
+                try await self.reload()
+            } catch let error as CancellationError where Task.isCancelled {
+                throw error
             } catch {
                 self.logger?.debug(
                     "Failed to reload certificate and private key.",
@@ -534,27 +589,52 @@ public struct TimedCertificateReloader: CertificateReloader {
     }
 
     /// Manually attempt a certificate and private key pair update.
+    @available(*, deprecated, message: "This can block the calling thread. Use the async overload instead.")
     public func reload() throws {
+        try self.reloadSynchronously()
+    }
+
+    /// Asynchronously attempt a certificate and private key pair update.
+    ///
+    /// Source loading is performed on a blocking I/O thread pool so this method does not block the calling executor.
+    public func reload() async throws {
         do {
-            let certificateBytes = try self.loadCertificate()
-            let keyBytes = try self.loadPrivateKey()
-
-            let certificates = try self.parseCertificates(from: certificateBytes)
-            let key = try self.parsePrivateKey(from: keyBytes)
-
-            guard let firstCertificate = certificates.first else {
-                throw Error.certificateLoadingError(reason: "The provided file does not contain any certificates.")
+            let (certificateBytes, keyBytes) = try await NIOThreadPool.singleton.runIfActive {
+                try (self.loadCertificate(), self.loadPrivateKey())
             }
-
-            guard key.publicKey == firstCertificate.publicKey else {
-                throw Error.publicKeyMismatch
-            }
-
-            try self.attemptToUpdatePair(certificates: certificates, key: key)
+            try self.reload(certificateBytes: certificateBytes, keyBytes: keyBytes)
+        } catch let error as CancellationError where Task.isCancelled {
+            throw error
         } catch {
             self.onCertificateLoadFailed?(CertificateChainAndKeyPairReloadFailure(error: error))
             throw error
         }
+    }
+
+    private func reloadSynchronously() throws {
+        do {
+            let certificateBytes = try self.loadCertificate()
+            let keyBytes = try self.loadPrivateKey()
+            try self.reload(certificateBytes: certificateBytes, keyBytes: keyBytes)
+        } catch {
+            self.onCertificateLoadFailed?(CertificateChainAndKeyPairReloadFailure(error: error))
+            throw error
+        }
+    }
+
+    private func reload(certificateBytes: [UInt8], keyBytes: [UInt8]) throws {
+        let certificates = try self.parseCertificates(from: certificateBytes)
+        let key = try self.parsePrivateKey(from: keyBytes)
+
+        guard let firstCertificate = certificates.first else {
+            throw Error.certificateLoadingError(reason: "The provided file does not contain any certificates.")
+        }
+
+        guard key.publicKey == firstCertificate.publicKey else {
+            throw Error.publicKeyMismatch
+        }
+
+        try self.attemptToUpdatePair(certificates: certificates, key: key)
     }
 
     private func loadCertificate() throws -> [UInt8] {

--- a/Tests/NIOCertificateReloadingTests/TimedCertificateReloaderTests.swift
+++ b/Tests/NIOCertificateReloadingTests/TimedCertificateReloaderTests.swift
@@ -44,9 +44,11 @@ final class TimedCertificateReloaderTests: XCTestCase {
                 XCTAssertNil(override.certificateChain)
                 XCTAssertNil(override.privateKey)
                 XCTAssertEqual(failureBox.withLockedValue { $0 }.count, 0)
-                let result = Result { try reloader.reload() }
+                do {
+                    try await reloader.reload()
+                    XCTFail("Reloading a missing certificate path should throw.")
+                } catch {}
                 XCTAssertEqual(failureBox.withLockedValue { $0 }.count, 1)
-                XCTAssertThrowsError(try result.get())
             }
         )
     }
@@ -361,6 +363,37 @@ final class TimedCertificateReloaderTests: XCTestCase {
         )
     }
 
+    func testAsyncReloadOffloadsSourceLoadingFromSwiftConcurrencyExecutor() async throws {
+        let certificateProviderWasRunningOnTask = NIOLockedValueBox<Bool?>(nil)
+        let callbackWasRunningOnTask = NIOLockedValueBox<Bool?>(nil)
+        let configuration = TimedCertificateReloader.Configuration(
+            refreshInterval: .seconds(10),
+            certificateSource: .init(
+                location: .memory(provider: {
+                    let isRunningOnTask = withUnsafeCurrentTask { $0 != nil }
+                    certificateProviderWasRunningOnTask.withLockedValue { $0 = isRunningOnTask }
+                    return try Self.sampleCert.serializeAsPEM().derBytes
+                }),
+                format: .der
+            ),
+            privateKeySource: .init(
+                location: .memory(provider: { Array(Self.samplePrivateKey1.derRepresentation) }),
+                format: .der
+            )
+        ) {
+            $0.onCertificateLoaded = { _ in
+                let isRunningOnTask = withUnsafeCurrentTask { $0 != nil }
+                callbackWasRunningOnTask.withLockedValue { $0 = isRunningOnTask }
+            }
+        }
+        let reloader = TimedCertificateReloader(configuration: configuration)
+
+        try await reloader.reload()
+
+        XCTAssertEqual(certificateProviderWasRunningOnTask.withLockedValue { $0 }, false)
+        XCTAssertEqual(callbackWasRunningOnTask.withLockedValue { $0 }, true)
+    }
+
     func testReloadSuccessfully_FromFile() async throws {
         // Start with empty files.
         let certificateFile = try self.createTempFile(contents: Data())
@@ -666,8 +699,8 @@ final class TimedCertificateReloaderTests: XCTestCase {
     }
 
     /// This tests the first makeReloaderValidatingSources helper function, which takes many parameters.
-    func testCreateValidating() throws {
-        let reloader = try TimedCertificateReloader.makeReloaderValidatingSources(
+    func testCreateValidating() async throws {
+        let reloader = try await TimedCertificateReloader.makeReloaderValidatingSources(
             refreshInterval: .milliseconds(50),
             certificateSource: .init(
                 location: .memory(provider: { try Self.sampleCert.serializeAsPEM().derBytes }),
@@ -690,7 +723,7 @@ final class TimedCertificateReloaderTests: XCTestCase {
     }
 
     /// This tests the other makeReloaderValidatingSources helper function, which takes a configuration.
-    func testCreateValidatingConfig() throws {
+    func testCreateValidatingConfig() async throws {
         let config = TimedCertificateReloader.Configuration(
             refreshInterval: .milliseconds(50),
             certificateSource: .init(
@@ -702,7 +735,7 @@ final class TimedCertificateReloaderTests: XCTestCase {
                 format: .der
             )
         )
-        let reloader = try TimedCertificateReloader.makeReloaderValidatingSources(configuration: config)
+        let reloader = try await TimedCertificateReloader.makeReloaderValidatingSources(configuration: config)
         // Cert should have been loaded once already
         XCTAssertEqual(
             reloader.sslContextConfigurationOverride.certificateChain,
@@ -715,7 +748,7 @@ final class TimedCertificateReloaderTests: XCTestCase {
     }
 
     /// This tests makeReloaderValidatingSources when the sources are not valid.
-    func testCreateValidatingConfigInvalid() throws {
+    func testCreateValidatingConfigInvalid() async throws {
         let config = TimedCertificateReloader.Configuration(
             refreshInterval: .milliseconds(50),
             certificateSource: .init(
@@ -727,14 +760,17 @@ final class TimedCertificateReloaderTests: XCTestCase {
                 format: .der
             )
         )
-        XCTAssertThrowsError(try TimedCertificateReloader.makeReloaderValidatingSources(configuration: config))
+        do {
+            _ = try await TimedCertificateReloader.makeReloaderValidatingSources(configuration: config)
+            XCTFail("Creating a reloader with invalid sources should throw.")
+        } catch {}
     }
 
     /// This tests that `makeServerConfigurationWithMTLS(certificateReloader:trustRoots:)` correctly extracts the
     /// certificate chain and private key from `certificateReloader` and sets those in the returned `TLSConfiguration`
     /// (along with `trustRoots` and setting `.certificateVerification` to `.noHostnameVerification`)
     func testCreateServerConfigWithMTLS() async throws {
-        let certificateReloader = try TimedCertificateReloader.makeReloaderValidatingSources(
+        let certificateReloader = try await TimedCertificateReloader.makeReloaderValidatingSources(
             refreshInterval: .seconds(10),
             certificateSource: .init(
                 location: .memory(provider: {
@@ -888,7 +924,7 @@ final class TimedCertificateReloaderTests: XCTestCase {
         let reloader = TimedCertificateReloader(configuration: config)
 
         if validateSources {
-            try reloader.reload()
+            try await reloader.reload()
         }
 
         try await withThrowingTaskGroup(of: Void.self) { group in


### PR DESCRIPTION
Make timed certificate reloads asynchronous without blocking Swift concurrency executors.

### Motivation:

`TimedCertificateReloader` currently loads certificate and private-key sources synchronously. File-backed sources may live on virtualized or networked filesystems, so performing this work directly can block an EventLoop or Swift concurrency executor.

Fixes #297.

### Modifications:

- Add async throwing overloads of `reload()` and `makeReloaderValidatingSources`, while deprecating the synchronous overloads.
- Run certificate and private-key source loading on `NIOThreadPool.singleton`.
- Keep parsing, state updates, and user callbacks outside the blocking thread pool.
- Make periodic reloads use the async path and propagate task cancellation.
- Add a regression test covering the source-loading and callback execution contexts.
- Add the explicit `NIOPosix` target dependency required for `NIOThreadPool`.

### Result:

Callers can migrate to an async API that keeps source loading off EventLoops and Swift concurrency threads. Existing synchronous call sites remain source-compatible with deprecation warnings.

### Testing:

- `swift test --filter TimedCertificateReloaderTests` — 25 tests passed on the final commit.
- Strict `NIOCertificateReloading` target build with warnings-as-errors, explicit sendability, and explicit dependency checking.
- Strict Swift format lint and `git diff --check`.

Local validation was performed on arm64 macOS. Linux, the repository Static SDK lane, Windows, and WASI were not run locally. An earlier near-final revision passed the full package suite, but that suite was not rerun against the exact final commit.
